### PR TITLE
Fixed pass/fail indicator on the left bar of the front end

### DIFF
--- a/src/main/resources/frontend/src/types/types.ts
+++ b/src/main/resources/frontend/src/types/types.ts
@@ -21,6 +21,7 @@ export type Submission = {
     score: number,
     notes: string,
     testResults: TestResult,
+    passed: boolean,
 }
 
 export type User = {

--- a/src/main/resources/frontend/src/views/PhaseView/PastSubmissions.vue
+++ b/src/main/resources/frontend/src/views/PhaseView/PastSubmissions.vue
@@ -17,7 +17,7 @@ useSubmissionStore().getSubmissions(props.phase);
 const isPassFail = props.phase !== '6';
 
 const passFail = (submission: Submission) => {
-  return submission.score >= 1 ? 'Pass' : 'Fail';
+  return submission.passed ? 'Pass' : 'Fail';
 }
 
 const submissionsByPhaseDesc = computed(() => {


### PR DESCRIPTION
pretty simple. It used to be that the "pass/fail" indicator was based purely on if it was over or under 100%. Now it uses the "passed" parameter from the database