### PR TITLE
90 frontend add logout option

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/src/main/java/edu/byu/cs/controller/CasController.java
+++ b/src/main/java/edu/byu/cs/controller/CasController.java
@@ -81,17 +81,17 @@ public class CasController {
         return null;
     };
 
-    public static Route logoutGet = (req, res) -> {
+    public static Route logoutPost = (req, res) -> {
         if (req.cookie("token") == null) {
-            res.status(401);
-            return "You are not logged in.";
+            res.redirect(ConfigProperties.frontendAppUrl(), 401);
+            return null;
         }
 
 
         // TODO: call cas logout endpoint with ticket
         res.removeCookie("/", "token");
-        res.status(200);
-        return "You are logged out.";
+        res.redirect(ConfigProperties.frontendAppUrl(), 302);
+        return null;
     };
 
     /**

--- a/src/main/java/edu/byu/cs/controller/CasController.java
+++ b/src/main/java/edu/byu/cs/controller/CasController.java
@@ -90,7 +90,7 @@ public class CasController {
 
         // TODO: call cas logout endpoint with ticket
         res.removeCookie("/", "token");
-        res.redirect(ConfigProperties.frontendAppUrl(), 302);
+        res.redirect(ConfigProperties.frontendAppUrl(), 200);
         return null;
     };
 

--- a/src/main/java/edu/byu/cs/controller/CasController.java
+++ b/src/main/java/edu/byu/cs/controller/CasController.java
@@ -87,7 +87,6 @@ public class CasController {
             return null;
         }
 
-
         // TODO: call cas logout endpoint with ticket
         res.removeCookie("/", "token");
         res.redirect(ConfigProperties.frontendAppUrl(), 200);

--- a/src/main/java/edu/byu/cs/server/Server.java
+++ b/src/main/java/edu/byu/cs/server/Server.java
@@ -34,7 +34,7 @@ public class Server {
 
             // all routes after this point require authentication
             post("/register", registerPost);
-            get("/logout", logoutGet);
+            post("/logout", logoutPost);
         });
 
         path("/api", () -> {

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -11,9 +11,9 @@ cas_server.login_endpoint=/login
 cas_server.service_validate_endpoint=/serviceValidate
 
 # The URL of the frontend application
-frontend_app.url=http://localhost:5173
+frontend_app.url=https://cs240.click
 
 # The URL of the backend application
-backend_app.url=http://localhost:8080
+backend_app.url=https://cs240.click
 
-backend_app.cas_callback_url=http://localhost:8080/auth/callback
+backend_app.cas_callback_url=https://students.cs.byu.edu/~cs240ta/ag/callback.php

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -11,9 +11,9 @@ cas_server.login_endpoint=/login
 cas_server.service_validate_endpoint=/serviceValidate
 
 # The URL of the frontend application
-frontend_app.url=https://cs240.click
+frontend_app.url=http://localhost:5173
 
 # The URL of the backend application
-backend_app.url=https://cs240.click
+backend_app.url=http://localhost:8080
 
-backend_app.cas_callback_url=https://students.cs.byu.edu/~cs240ta/ag/callback.php
+backend_app.cas_callback_url=http://localhost:8080/auth/callback

--- a/src/main/resources/frontend/src/App.vue
+++ b/src/main/resources/frontend/src/App.vue
@@ -18,7 +18,6 @@ const logOut = async () => {
   } catch (e) {
     alert(e)
   }
-  alert("You have logged out")
   router.push({name: "login"})
 
 }

--- a/src/main/resources/frontend/src/App.vue
+++ b/src/main/resources/frontend/src/App.vue
@@ -2,19 +2,33 @@
 
 import { computed, h } from 'vue'
 import {useAuthStore} from "@/stores/auth";
+import { logoutPost } from '@/services/authService'
+import router from '@/router'
 
 const greeting = computed(() => {
   if (useAuthStore().isLoggedIn) {
     return `${useAuthStore().user?.firstName} ${useAuthStore().user?.lastName} - ${useAuthStore().user?.netId} (${useAuthStore().user?.role.toLowerCase()}) - `
   }
 });
+
+const logOut = async () => {
+  try {
+    await logoutPost()
+    useAuthStore().user = null
+  } catch (e) {
+    alert(e)
+  }
+  alert("You have logged out")
+  router.push({name: "login"})
+
+}
 </script>
 
 <template>
   <header>
     <h1>CS 240 Autograder</h1>
     <h3>This is where you can submit your assignments and view your scores.</h3>
-    <p>{{ greeting }} <a v-if="useAuthStore().isLoggedIn" href="auth/logout">Logout</a></p>
+    <p>{{ greeting }} <a v-if="useAuthStore().isLoggedIn" @click="logOut">Logout</a></p>
     <p>{{ useAuthStore().user?.repoUrl }}</p>
   </header>
   <main>

--- a/src/main/resources/frontend/src/App.vue
+++ b/src/main/resources/frontend/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 
-import { computed, h } from 'vue'
+import { computed } from 'vue'
 import {useAuthStore} from "@/stores/auth";
 import { logoutPost } from '@/services/authService'
 import router from '@/router'
@@ -67,5 +67,7 @@ main {
 
 a {
   color: white;
+  text-decoration: underline;
+  cursor: pointer;
 }
 </style>

--- a/src/main/resources/frontend/src/App.vue
+++ b/src/main/resources/frontend/src/App.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 
-import {computed} from "vue";
+import { computed, h } from 'vue'
 import {useAuthStore} from "@/stores/auth";
 
 const greeting = computed(() => {
   if (useAuthStore().isLoggedIn) {
-    return `${useAuthStore().user?.firstName} ${useAuthStore().user?.lastName} - ${useAuthStore().user?.netId} (${useAuthStore().user?.role.toLowerCase()})`
+    return `${useAuthStore().user?.firstName} ${useAuthStore().user?.lastName} - ${useAuthStore().user?.netId} (${useAuthStore().user?.role.toLowerCase()}) - `
   }
 });
 </script>
@@ -14,7 +14,7 @@ const greeting = computed(() => {
   <header>
     <h1>CS 240 Autograder</h1>
     <h3>This is where you can submit your assignments and view your scores.</h3>
-    <p>{{ greeting }}</p>
+    <p>{{ greeting }} <a v-if="useAuthStore().isLoggedIn" href="auth/logout">Logout</a></p>
     <p>{{ useAuthStore().user?.repoUrl }}</p>
   </header>
   <main>
@@ -49,5 +49,9 @@ main {
   width: 66vw;
 
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
+}
+
+a {
+  color: white;
 }
 </style>

--- a/src/main/resources/frontend/src/services/authService.ts
+++ b/src/main/resources/frontend/src/services/authService.ts
@@ -32,3 +32,18 @@ export const registerPost = async (firstName: string, lastName: string, repoUrl:
 
     return response.ok;
 }
+
+export const logoutPost = async () => {
+    const response = await fetch(useAppConfigStore().backendUrl + "/auth/logout", {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    });
+
+    if (!response.ok) {
+        console.error(response);
+        throw new Error(await response.text());
+    }
+}

--- a/src/main/resources/frontend/src/views/LoginView.vue
+++ b/src/main/resources/frontend/src/views/LoginView.vue
@@ -11,7 +11,7 @@ onBeforeMount(async () => {
     return;
 
   useAuthStore().user = loggedInUser;
-  await router.push({name: 'home'});
+  router.push({ name: 'home' });
 })
 
 const login = () => {


### PR DESCRIPTION
this pull requests adds a front end logout

**Old Behavior:**
to log out, you had to navigate to /auth/logout, which would call a GET rest method on the back end, and return a simple string

**New Behavior**
if you are logged in, next to your name and NetID there is a "Logout" link that calls a POST rest method on the back end, pops up an alert to the user indicating they are logged out, and returns them to the login page. 
This DOES NOT log them out of CAS. The old behavior didn't log them out of CAS either.