### PR TITLE
Add Honor Checker File Download

### DIFF
--- a/src/main/java/edu/byu/cs/controller/AdminController.java
+++ b/src/main/java/edu/byu/cs/controller/AdminController.java
@@ -5,10 +5,13 @@ import edu.byu.cs.analytics.CommitAnalyticsRouter;
 import edu.byu.cs.canvas.CanvasIntegration;
 import edu.byu.cs.dataAccess.DaoService;
 import edu.byu.cs.dataAccess.UserDao;
+import edu.byu.cs.honorChecker.HonorCheckerCompiler;
 import edu.byu.cs.model.User;
 import org.slf4j.LoggerFactory;
 import spark.Route;
 
+import java.io.FileInputStream;
+import java.io.OutputStream;
 import java.util.Collection;
 
 import static edu.byu.cs.util.JwtUtils.generateToken;
@@ -108,5 +111,32 @@ public class AdminController {
         res.status(200);
 
         return data;
+    };
+
+    public static Route honorCheckerZipGet = (req, res) -> {
+        String sectionStr = req.params(":section");
+        String filePath;
+
+        res.header("Content-Type", "application/zip");
+        res.header("Content-Disposition", "attachment; filename=" + "downloaded_file.zip");
+
+        try {
+            filePath = HonorCheckerCompiler.compileSection(Integer.parseInt(sectionStr));
+            try (FileInputStream fis = new FileInputStream(filePath);
+                 OutputStream os = res.raw().getOutputStream()) {
+
+                byte[] buffer = new byte[4096];
+                int bytesRead;
+                while ((bytesRead = fis.read(buffer)) != -1) {
+                    os.write(buffer, 0, bytesRead);
+                }
+
+                res.status(200);
+                return res.raw();
+            }
+        } catch (Exception e) {
+            res.status(500);
+            return e.getMessage();
+        }
     };
 }

--- a/src/main/java/edu/byu/cs/honorChecker/HonorCheckerCompiler.java
+++ b/src/main/java/edu/byu/cs/honorChecker/HonorCheckerCompiler.java
@@ -1,0 +1,74 @@
+package edu.byu.cs.honorChecker;
+
+import edu.byu.cs.canvas.CanvasException;
+import edu.byu.cs.canvas.CanvasIntegration;
+import edu.byu.cs.model.User;
+import edu.byu.cs.util.FileUtils;
+import org.eclipse.jgit.api.CloneCommand;
+import org.eclipse.jgit.api.Git;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.function.Consumer;
+
+public class HonorCheckerCompiler {
+
+    /**
+     * Creates a .zip file for all students' repos in the given section
+     *
+     * @param section the section number (not ID)
+     * @return the path to the .zip file
+     */
+    public static String compileSection(int section) {
+        int sectionID = CanvasIntegration.sectionIDs.get(section);
+        String tmpDir = "tmp-section-" + section;
+        String zipFilePath = "section-" + section + ".zip";
+
+        FileUtils.createDirectory(tmpDir);
+
+        Collection<User> students;
+        try {
+            students = CanvasIntegration.getAllStudentsBySection(sectionID);
+        } catch (CanvasException e) {
+            throw new RuntimeException("Canvas Exception: " + e.getMessage());
+        }
+
+        try {
+            for (User student : students) {
+                File repoPath = new File(tmpDir, student.netId());
+
+                CloneCommand cloneCommand = Git.cloneRepository()
+                        .setURI(student.repoUrl())
+                        .setDirectory(repoPath);
+
+                try {
+                    Git git = cloneCommand.call();
+                    git.close();
+                } catch (Exception e) {
+                    FileUtils.removeDirectory(repoPath);
+                    continue;
+                }
+
+                // delete everything except modules
+                Consumer<File> action = file -> {
+                    String prefix = repoPath + File.separator;
+                    if (!file.getPath().startsWith(prefix + "client") &&
+                        !file.getPath().startsWith(prefix + "server") &&
+                        !file.getPath().startsWith(prefix + "shared")) {
+                        file.delete();
+                    }
+                };
+                FileUtils.modifyDirectory(new File(repoPath.getPath()), action);
+            }
+
+            FileUtils.zipDirectory(tmpDir, zipFilePath);
+        } catch (RuntimeException e) {
+            FileUtils.removeDirectory(new File(tmpDir));
+            new File(zipFilePath).delete();
+            throw e;
+        }
+
+        FileUtils.removeDirectory(new File(tmpDir));
+        return zipFilePath;
+    }
+}

--- a/src/main/java/edu/byu/cs/server/Server.java
+++ b/src/main/java/edu/byu/cs/server/Server.java
@@ -67,6 +67,8 @@ public class Server {
                 get("/submissions/active", submissionsActiveGet);
 
                 get("/analytics/commit/:option", commitAnalyticsGet);
+
+                get("/honorChecker/zip/:section", honorCheckerZipGet);
             });
         });
 

--- a/src/main/java/edu/byu/cs/util/FileUtils.java
+++ b/src/main/java/edu/byu/cs/util/FileUtils.java
@@ -7,6 +7,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 public class FileUtils {
@@ -71,6 +72,16 @@ public class FileUtils {
      * @param dir the directory to delete
      */
     public static void removeDirectory(File dir) {
+        modifyDirectory(dir, File::delete);
+    }
+
+    /**
+     * Iterates through a directory and executes the provided action on each file
+     *
+     * @param dir the directory to modify
+     * @param action the action to perform on each file
+     */
+    public static void modifyDirectory(File dir, Consumer<File> action) {
         if (!dir.exists()) {
             return;
         }
@@ -78,7 +89,7 @@ public class FileUtils {
         try (Stream<Path> paths = Files.walk(dir.toPath())) {
             paths.sorted(Comparator.reverseOrder())
                     .map(Path::toFile)
-                    .forEach(File::delete);
+                    .forEach(action);
         } catch (IOException e) {
             LoggerFactory.getLogger(FileUtils.class).error("Failed to delete stage directory", e);
             throw new RuntimeException("Failed to delete directory: " + e.getMessage());

--- a/src/main/java/edu/byu/cs/util/FileUtils.java
+++ b/src/main/java/edu/byu/cs/util/FileUtils.java
@@ -132,7 +132,6 @@ public class FileUtils {
 
             zipOut.close();
             fos.close();
-            System.out.println("Directory successfully zipped at: " + zipFilePath);
         } catch (IOException e) {
             throw new RuntimeException("Failed to zip directory: " + e.getMessage());
         }

--- a/src/main/java/edu/byu/cs/util/FileUtils.java
+++ b/src/main/java/edu/byu/cs/util/FileUtils.java
@@ -9,6 +9,8 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 public class FileUtils {
 
@@ -112,5 +114,52 @@ public class FileUtils {
         }
 
         return null;
+    }
+
+    /**
+     * Creates a .zip file from a directory
+     *
+     * @param sourceDirectoryPath the directory to compress
+     * @param zipFilePath the path of the .zip file to be created
+     */
+    public static void zipDirectory(String sourceDirectoryPath, String zipFilePath) {
+        try {
+            File sourceDirectory = new File(sourceDirectoryPath);
+            FileOutputStream fos = new FileOutputStream(zipFilePath);
+            ZipOutputStream zipOut = new ZipOutputStream(fos);
+
+            zipDirectoryContents(sourceDirectory, sourceDirectory, zipOut);
+
+            zipOut.close();
+            fos.close();
+            System.out.println("Directory successfully zipped at: " + zipFilePath);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to zip directory: " + e.getMessage());
+        }
+    }
+
+    private static void zipDirectoryContents(File rootDirectory, File currentDirectory, ZipOutputStream zipOut) throws IOException {
+        File[] files = currentDirectory.listFiles();
+
+        for (File file : files) {
+            if (file.isDirectory()) {
+                zipDirectoryContents(rootDirectory, file, zipOut);
+            } else {
+                FileInputStream fis = new FileInputStream(file);
+
+                String entryName = rootDirectory.toURI().relativize(file.toURI()).getPath();
+
+                ZipEntry zipEntry = new ZipEntry(entryName);
+                zipOut.putNextEntry(zipEntry);
+
+                byte[] bytes = new byte[1024];
+                int length;
+                while ((length = fis.read(bytes)) >= 0) {
+                    zipOut.write(bytes, 0, length);
+                }
+
+                fis.close();
+            }
+        }
     }
 }

--- a/src/main/resources/frontend/src/services/adminService.ts
+++ b/src/main/resources/frontend/src/services/adminService.ts
@@ -112,3 +112,15 @@ export const commitAnalyticsGet = async (option: Option): Promise<string> => {
         return ''
     }
 }
+
+export const honorCheckerZipGet = async (section: number): Promise<Blob> => {
+    try {
+        return (await fetch(useAppConfigStore().backendUrl + '/api/admin/honorChecker/zip/' + section, {
+            method: 'GET',
+            credentials: 'include'
+        })).blob()
+    } catch (e) {
+        console.error('Failed to get data: ', e)
+        return new Blob()
+    }
+}

--- a/src/main/resources/frontend/src/views/AdminView/AdminView.vue
+++ b/src/main/resources/frontend/src/views/AdminView/AdminView.vue
@@ -8,6 +8,7 @@ import Admins from "@/views/AdminView/Admins/Admins.vue";
 import {testStudentModeGet} from "@/services/adminService";
 import QueueStatus from "@/views/AdminView/QueueStatus.vue";
 import Analytics from "@/views/AdminView/Analytics.vue";
+import HonorChecker from "@/views/AdminView/HonorChecker.vue";
 
 const activateTestStudentMode = async () => {
   await testStudentModeGet()
@@ -45,6 +46,9 @@ const activateTestStudentMode = async () => {
       </Tab>
       <Tab title="Analytics">
         <Analytics/>
+      </Tab>
+      <Tab title="Honor Checker">
+        <HonorChecker/>
       </Tab>
     </Tabs>
   </div>

--- a/src/main/resources/frontend/src/views/AdminView/HonorChecker.vue
+++ b/src/main/resources/frontend/src/views/AdminView/HonorChecker.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+
+import {ref} from "vue";
+import {honorCheckerZipGet} from "@/services/adminService";
+
+const selectedSection = ref<number>(1)
+const infoText = ref<string>('')
+const buttonDisabled = ref<boolean>(false)
+
+const onSelectionChange = (event) => {
+  selectedSection.value = event.target.value
+}
+
+const getData = async () => {
+  buttonDisabled.value = true
+  infoText.value = 'Downloading... (this shouldn\'t take more than 30 seconds)'
+  const data: Blob = await honorCheckerZipGet(selectedSection.value)
+  triggerDownload(data, 'section-' + selectedSection.value + '.zip')
+  if (data.size == 0) {
+    infoText.value = 'Error occurred server side. Check logs or browser console.'
+  } else {
+    infoText.value = 'Complete! Check your downloads folder for the .zip file.'
+  }
+  buttonDisabled.value = false
+}
+
+const triggerDownload = (data: Blob, filename: string) => {
+  const link = document.createElement('a')
+
+  link.href = window.URL.createObjectURL(data)
+  link.download = filename
+
+  document.body.appendChild(link)
+
+  link.click()
+
+  document.body.removeChild(link)
+}
+
+</script>
+
+<template>
+  <div class="container">
+    <p class="desc">If you are a professor who wants to run the honor checker on your section, you've come to the
+        right place! The honor checker itself is located elsewhere, but below, you can download .zip files of your section(s).
+        Each .zip file contains a directory for every student containing their source code.</p>
+    <label for="section">Choose a section to download: </label>
+    <select name="section" @change="onSelectionChange">
+      <option value="1">Section 1</option>
+      <option value="2">Section 2</option>
+      <option value="3">Section 3</option>
+      <option value="4">Section 4</option>
+      <option value="5">Section 5</option>
+    </select>
+    <button :disabled="buttonDisabled" @click="getData">Download</button>
+    <p>{{ infoText }}</p>
+  </div>
+</template>
+
+<style scoped>
+.container {
+  padding: 10px;
+  text-align: center;
+}
+
+.desc {
+  text-align: center;
+  width: 70%;
+  margin: 0 auto;
+}
+
+button {
+  margin: 1rem;
+}
+</style>


### PR DESCRIPTION
## New Frontend Features
A tab on the admin page with the option to download a .zip of all the students' repos in a given section.

## New Backend Features
A new endpoint (`/api/admin/honorChecker/zip/:section`) that connects to a service that given a section number, clones every student's git repo and zips up the revelvant files (the 3 modules, nothing else). The resulting .zip file contains every student's repo without extra code (this results in the .zip files being around 2-3 MB per section instead of 6-7).