### PR TITLE
Add standard error drain

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/QualityAnalyzer.java
+++ b/src/main/java/edu/byu/cs/autograder/QualityAnalyzer.java
@@ -34,7 +34,7 @@ public class QualityAnalyzer {
         ProcessBuilder processBuilder = new ProcessBuilder().directory(stageRepo.getParentFile())
                 .command("java", "-jar", checkStyleJarPath, "-c", "cs240_checks.xml", "repo");
 
-        String output = ProcessUtils.runProcess(processBuilder);
+        String output = ProcessUtils.runProcess(processBuilder)[0];
 
         output = output.replaceAll(stageRepo.getAbsolutePath(), "");
         output = output.replaceAll(stageRepo.getPath(), "");

--- a/src/main/java/edu/byu/cs/autograder/TestHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/TestHelper.java
@@ -68,7 +68,7 @@ public class TestHelper {
                     .directory(testsLocation)
                     .command(findCommands);
 
-            String findOutput = ProcessUtils.runProcess(findProcessBuilder).replace("\n", " ");
+            String findOutput = ProcessUtils.runProcess(findProcessBuilder)[0].replace("\n", " ");
 
             /* Compile files */
             String chessJarWithDeps;
@@ -143,7 +143,7 @@ public class TestHelper {
                 .directory(compiledTests)
                 .command(commands);
 
-        String output = ProcessUtils.runProcess(processBuilder);
+        String output = ProcessUtils.runProcess(processBuilder)[0];
 
         TestAnalyzer testAnalyzer = new TestAnalyzer();
         return testAnalyzer.parse(output.split("\n"), extraCreditTests);

--- a/src/main/java/edu/byu/cs/util/ProcessUtils.java
+++ b/src/main/java/edu/byu/cs/util/ProcessUtils.java
@@ -17,8 +17,8 @@ public class ProcessUtils {
      * @param processBuilder process to run
      * @return output from process standard out
      */
-    public static String runProcess(ProcessBuilder processBuilder) {
-        try (ExecutorService processOutputExecutor = Executors.newSingleThreadExecutor()){
+    public static String[] runProcess(ProcessBuilder processBuilder) {
+        try (ExecutorService processOutputExecutor = Executors.newFixedThreadPool(2)){
 
             Process process = processBuilder.start();
 
@@ -28,43 +28,41 @@ public class ProcessUtils {
             writes to block, resulting in the process never finishing. This is usually the result of the tested
             code printing out too many lines to stdout as a means of logging/debugging
              */
-            Future<String> processOutputFuture = processOutputExecutor.submit(() -> getOutputFromProcess(process));
+            Future<String> processOutputFuture = processOutputExecutor.submit(() -> getOutputFromInputStream(process.getInputStream()));
+            Future<String> processErrorFuture = processOutputExecutor.submit(() -> getOutputFromInputStream(process.getErrorStream()));
 
             if (!process.waitFor(30000, TimeUnit.MILLISECONDS)) {
                 process.destroyForcibly();
                 LOGGER.error("Submission took too long to grade, come see a TA for more info");
                 throw new RuntimeException("Submission took too long to grade, come see a TA for more info");
             }
+            String output = processOutputFuture.get(1000, TimeUnit.MILLISECONDS);
+            String error = processErrorFuture.get(1000, TimeUnit.MILLISECONDS);
 
-            return processOutputFuture.get(1000, TimeUnit.MILLISECONDS);
+            return new String[]{output, error};
         } catch (IOException | InterruptedException | ExecutionException | TimeoutException e) {
             throw new RuntimeException(e);
         }
     }
 
     /**
-     * Extracts the output as a string from a process
+     * Extracts the output as a string from an input stream
      *
-     * @param process The process to extract the output from
+     * @param is The input stream to extract the output from
      * @return The output of the process as a string
      * @throws IOException If an error occurs while reading the output
      */
-    private static String getOutputFromProcess(Process process) throws IOException {
-        String output;
+    private static String getOutputFromInputStream(InputStream is) throws IOException {
+        try (InputStreamReader isr = new InputStreamReader(is);
+             BufferedReader br = new BufferedReader(isr)){
 
-        InputStream is = process.getInputStream();
-        InputStreamReader isr = new InputStreamReader(is);
-        BufferedReader br = new BufferedReader(isr);
-        {
             String line;
             StringBuilder sb = new StringBuilder();
             while ((line = br.readLine()) != null) {
                 sb.append(line);
                 sb.append('\n');
             }
-
-            output = sb.toString();
+            return sb.toString();
         }
-        return output;
     }
 }


### PR DESCRIPTION
This drains both standard out and standard error, and returns the output as an array of strings in case anyone wants the output of standard error (although no code is now)