### PR TITLE
212 admin add panel for student information

### DIFF
--- a/src/main/java/edu/byu/cs/controller/SubmissionController.java
+++ b/src/main/java/edu/byu/cs/controller/SubmissionController.java
@@ -8,6 +8,7 @@ import edu.byu.cs.canvas.CanvasIntegration;
 import edu.byu.cs.controller.netmodel.GradeRequest;
 import edu.byu.cs.dataAccess.DaoService;
 import edu.byu.cs.dataAccess.QueueDao;
+import edu.byu.cs.dataAccess.SubmissionDao;
 import edu.byu.cs.dataAccess.UserDao;
 import edu.byu.cs.model.*;
 import edu.byu.cs.util.PhaseUtils;
@@ -218,6 +219,20 @@ public class SubmissionController {
                 "currentlyGrading", currentlyGrading,
                 "inQueue", inQueue
         ));
+    };
+
+    public static Route studentSubmissionsGet = (req, res) -> {
+        String netId = req.params(":netId");
+
+        SubmissionDao submissionDao = DaoService.getSubmissionDao();
+        Collection<Submission> submissions = submissionDao.getSubmissionsForUser(netId);
+
+        res.status(200);
+        res.type("application/json");
+
+        return new GsonBuilder()
+                .registerTypeAdapter(Instant.class, new Submission.InstantAdapter())
+                .create().toJson(submissions);
     };
 
     /**

--- a/src/main/java/edu/byu/cs/server/Server.java
+++ b/src/main/java/edu/byu/cs/server/Server.java
@@ -69,6 +69,8 @@ public class Server {
 
                 get("/submissions/active", submissionsActiveGet);
 
+                get("/submissions/student/:netID", studentSubmissionsGet);
+
                 post("/submissions/rerun", submissionsReRunPost);
 
                 get("/analytics/commit", commitAnalyticsGet);

--- a/src/main/resources/frontend/package.json
+++ b/src/main/resources/frontend/package.json
@@ -13,6 +13,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "ag-grid-vue3": "^31.1.1",
     "pinia": "^2.1.7",
     "vue": "^3.3.11",
     "vue-router": "^4.2.5"

--- a/src/main/resources/frontend/src/services/adminService.ts
+++ b/src/main/resources/frontend/src/services/adminService.ts
@@ -66,6 +66,19 @@ export const submissionsLatestGet = async (): Promise<Submission[]> => {
     }
 }
 
+export const studentListGet = async (): Promise<Submission[]> => {
+    try {
+        const response = await fetch(useAppConfigStore().backendUrl + '/api/admin/submissions/latest', {
+            method: 'GET',
+            credentials: 'include'
+        });
+
+        return await response.json();
+    } catch (e) {
+        return [];
+    }
+}
+
 export const testStudentModeGet = async (): Promise<null> => {
     try {
         const response = await fetch(useAppConfigStore().backendUrl + '/api/admin/test_mode', {

--- a/src/main/resources/frontend/src/services/adminService.ts
+++ b/src/main/resources/frontend/src/services/adminService.ts
@@ -66,19 +66,6 @@ export const submissionsLatestGet = async (): Promise<Submission[]> => {
     }
 }
 
-export const studentListGet = async (): Promise<Submission[]> => {
-    try {
-        const response = await fetch(useAppConfigStore().backendUrl + '/api/admin/submissions/latest', {
-            method: 'GET',
-            credentials: 'include'
-        });
-
-        return await response.json();
-    } catch (e) {
-        return [];
-    }
-}
-
 export const testStudentModeGet = async (): Promise<null> => {
     try {
         const response = await fetch(useAppConfigStore().backendUrl + '/api/admin/test_mode', {

--- a/src/main/resources/frontend/src/services/adminService.ts
+++ b/src/main/resources/frontend/src/services/adminService.ts
@@ -15,6 +15,19 @@ export const usersGet = async (): Promise<User[]> => {
     }
 }
 
+export const submissionsForUserGet = async (netID: string): Promise<Submission[]> => {
+    try {
+        const response = await fetch(useAppConfigStore().backendUrl + '/api/admin/submissions/student/' + netID, {
+            method: 'GET',
+            credentials: 'include'
+        });
+
+        return await response.json();
+    } catch (e) {
+        return [];
+    }
+}
+
 interface UserPatch {
     netId: string,
     firstName?: string,

--- a/src/main/resources/frontend/src/views/AdminView/AdminView.vue
+++ b/src/main/resources/frontend/src/views/AdminView/AdminView.vue
@@ -9,6 +9,7 @@ import QueueStatus from "@/views/AdminView/QueueStatus.vue";
 import Analytics from "@/views/AdminView/Analytics.vue";
 import HonorChecker from "@/views/AdminView/HonorChecker.vue";
 import {useAdminStore} from "@/stores/admin";
+import Students from "@/views/AdminView/Students.vue";
 
 useAdminStore().updateUsers();
 
@@ -31,6 +32,9 @@ const activateTestStudentMode = async () => {
     <Tabs>
       <Tab title="Submissions">
         <SubmissionsView/>
+      </Tab>
+      <Tab title="Students">
+        <Students/>
       </Tab>
       <Tab disabled title="Exceptions">
         <Exceptions/>

--- a/src/main/resources/frontend/src/views/AdminView/StudentInfo.vue
+++ b/src/main/resources/frontend/src/views/AdminView/StudentInfo.vue
@@ -27,7 +27,8 @@ onMounted(async () => {
           time: submission.timestamp,
           score: (submission.score * 100) + "%",
           notes: submission.notes,
-          rubric: submission.rubric
+          rubric: submission.rubric,
+          passed: submission.passed
         }
     )
   })
@@ -47,14 +48,12 @@ const columnDefs = reactive([
 const rowData = reactive({
   value: []
 })
-
 </script>
 
 <template>
-  <h4>Student Info</h4>
   <h3>{{student.firstName}} {{student.lastName}}</h3>
-  <p class="netID">netID: {{student.netId}}</p>
-  <p class="repo">Github Repo: <a href="{{student.repoUrl}}">{{student.repoUrl}}</a> </p>
+  <p>netID: {{student.netId}}</p>
+  <p>Github Repo: <a href="{{student.repoUrl}}">{{student.repoUrl}}</a> </p>
 
   <ag-grid-vue
       class="ag-theme-alpine"
@@ -71,5 +70,8 @@ const rowData = reactive({
 </template>
 
 <style scoped>
-
+a:visited, a {
+  color: darkblue;
+  font-style: italic;
+}
 </style>

--- a/src/main/resources/frontend/src/views/AdminView/StudentInfo.vue
+++ b/src/main/resources/frontend/src/views/AdminView/StudentInfo.vue
@@ -5,7 +5,7 @@ import {submissionsForUserGet, usersGet} from "@/services/adminService";
 import { AgGridVue } from 'ag-grid-vue3';
 import type { ValueGetterParams, CellClickedEvent } from 'ag-grid-community'
 import 'ag-grid-community/styles/ag-grid.css';
-import "ag-grid-community/styles/ag-theme-alpine.css";
+import "ag-grid-community/styles/ag-theme-quartz.css";
 import RubricTable from "@/views/PhaseView/RubricTable.vue";
 import PopUp from "@/components/PopUp.vue";
 
@@ -56,7 +56,7 @@ const rowData = reactive({
   <p>Github Repo: <a href="{{student.repoUrl}}">{{student.repoUrl}}</a> </p>
 
   <ag-grid-vue
-      class="ag-theme-alpine"
+      class="ag-theme-quartz"
       style="height: 35vh; width: 60vw"
       :columnDefs="columnDefs"
       :rowData="rowData.value"

--- a/src/main/resources/frontend/src/views/AdminView/StudentInfo.vue
+++ b/src/main/resources/frontend/src/views/AdminView/StudentInfo.vue
@@ -53,7 +53,7 @@ const rowData = reactive({
 <template>
   <h3>{{student.firstName}} {{student.lastName}}</h3>
   <p>netID: {{student.netId}}</p>
-  <p>Github Repo: <a href="{{student.repoUrl}}">{{student.repoUrl}}</a> </p>
+  <p>Github Repo: <a :href=student.repoUrl target="_blank">{{student.repoUrl}}</a> </p>
 
   <ag-grid-vue
       class="ag-theme-quartz"

--- a/src/main/resources/frontend/src/views/AdminView/StudentInfo.vue
+++ b/src/main/resources/frontend/src/views/AdminView/StudentInfo.vue
@@ -1,9 +1,52 @@
 <script setup lang="ts">
-import type {User} from "@/types/types";
+import type {Rubric, Submission, User} from "@/types/types";
+import {onMounted, reactive, ref} from "vue";
+import {submissionsForUserGet, usersGet} from "@/services/adminService";
+import { AgGridVue } from 'ag-grid-vue3';
+import type { ValueGetterParams, CellClickedEvent } from 'ag-grid-community'
+import 'ag-grid-community/styles/ag-grid.css';
+import "ag-grid-community/styles/ag-theme-alpine.css";
+import RubricTable from "@/views/PhaseView/RubricTable.vue";
+import PopUp from "@/components/PopUp.vue";
 
-defineProps<{
+const { student } = defineProps<{
   student: User;
 }>();
+
+const studentSubmissions = ref<Submission[]>([])
+
+const selectedRubric = ref<Rubric | null>(null);
+
+onMounted(async () => {
+  studentSubmissions.value = await submissionsForUserGet(student.netId);
+  var dataToShow: any = []
+  studentSubmissions.value.forEach(submission => {
+    dataToShow.push(
+        {
+          phase: submission.phase,
+          time: submission.timestamp,
+          score: (submission.score * 100) + "%",
+          notes: submission.notes,
+          rubric: submission.rubric
+        }
+    )
+  })
+  rowData.value = dataToShow
+});
+
+const cellClickHandler = (event: CellClickedEvent) => {
+  selectedRubric.value = event.data.rubric;
+}
+
+const columnDefs = reactive([
+  { headerName: "Phase", field: 'phase', sortable: true, filter: true, flex:1},
+  { headerName: "Timestamp", field: "time", sortable: true, filter: true, flex:2 },
+  { headerName: "Score", field: "score", sortable: true, filter: true, flex:1 },
+  { headerName: "Notes", field: "notes", sortable: true, filter: true, flex:5, onCellClicked: cellClickHandler }
+])
+const rowData = reactive({
+  value: []
+})
 
 </script>
 
@@ -12,6 +55,19 @@ defineProps<{
   <h3>{{student.firstName}} {{student.lastName}}</h3>
   <p class="netID">netID: {{student.netId}}</p>
   <p class="repo">Github Repo: <a href="{{student.repoUrl}}">{{student.repoUrl}}</a> </p>
+
+  <ag-grid-vue
+      class="ag-theme-alpine"
+      style="height: 35vh; width: 60vw"
+      :columnDefs="columnDefs"
+      :rowData="rowData.value"
+  ></ag-grid-vue>
+
+  <PopUp
+      v-if="selectedRubric"
+      @closePopUp="selectedRubric = null">
+    <RubricTable :rubric="selectedRubric"/>
+  </PopUp>
 </template>
 
 <style scoped>

--- a/src/main/resources/frontend/src/views/AdminView/StudentInfo.vue
+++ b/src/main/resources/frontend/src/views/AdminView/StudentInfo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type {Rubric, Submission, User} from "@/types/types";
 import {onMounted, reactive, ref} from "vue";
-import {submissionsForUserGet, usersGet} from "@/services/adminService";
+import {submissionsForUserGet} from "@/services/adminService";
 import { AgGridVue } from 'ag-grid-vue3';
-import type { ValueGetterParams, CellClickedEvent } from 'ag-grid-community'
+import type { CellClickedEvent } from 'ag-grid-community'
 import 'ag-grid-community/styles/ag-grid.css';
 import "ag-grid-community/styles/ag-theme-quartz.css";
 import RubricTable from "@/views/PhaseView/RubricTable.vue";

--- a/src/main/resources/frontend/src/views/AdminView/StudentInfo.vue
+++ b/src/main/resources/frontend/src/views/AdminView/StudentInfo.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import type {User} from "@/types/types";
+
+defineProps<{
+  student: User;
+}>();
+
+</script>
+
+<template>
+  <h4>Student Info</h4>
+  <h3>{{student.firstName}} {{student.lastName}}</h3>
+  <p class="netID">netID: {{student.netId}}</p>
+  <p class="repo">Github Repo: <a href="{{student.repoUrl}}">{{student.repoUrl}}</a> </p>
+</template>
+
+<style scoped>
+
+</style>

--- a/src/main/resources/frontend/src/views/AdminView/Students.vue
+++ b/src/main/resources/frontend/src/views/AdminView/Students.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { AgGridVue } from 'ag-grid-vue3';
+import 'ag-grid-community/styles/ag-grid.css';
+import "ag-grid-community/styles/ag-theme-alpine.css";
+
+// eslint-disable-next-line vue/no-export-in-script-setup
+const columnDefs = [
+        { headerName: "Name", field: 'name'},
+        { headerName: "BYU netID", field: "netID"},
+        { headerName: "Github URL", field: "github", flex:1}
+      ]
+const rowData = [
+        {name: "Roger McGee", netID: "rogerm", github: "http://girthagk.com"},
+        {name: "Steve McGee", netID: "stevem", github: "http://github.com"},
+        {name: "Roger McGee", netID: "rogerm", github: "http://github.com"},
+        {name: "Steve McGee", netID: "stevem", github: "http://github.com"},
+        {name: "Roger McGee", netID: "rogerm", github: "http://github.com"},
+        {name: "Steve McGee", netID: "stevem", github: "http://github.com"},
+        {name: "Roger McGee", netID: "rogerm", github: "http://github.com"},
+        {name: "Steve McGee", netID: "stevem", github: "http://github.com"},
+        {name: "Roger McGee", netID: "rogerm", github: "http://github.com"},
+        {name: "Steve McGee", netID: "stevem", github: "http://github.comasdfghdfgdhdsasfgdfhfjfrewrtyhgftryhgfd"},
+        {name: "Roger McGee", netID: "rogerm", github: "http://github.com"},
+        {name: "Steve McGee", netID: "stevem", github: "http://github.com"},
+        {name: "Roger McGee", netID: "rogerm", github: "http://github.com"},
+        {name: "Steve McGee", netID: "stevem", github: "http://github.com"},
+        {name: "Roger McGee", netID: "rogerm", github: "http://github.com"},
+        {name: "Steve McGee", netID: "stevem", github: "http://github.com"},
+        {name: "Roger McGee", netID: "rogerm", github: "http://github.com"},
+        {name: "Steve McGee", netID: "stevem", github: "http://github.com"},
+      ]
+</script>
+
+<template>
+  <ag-grid-vue
+      class="ag-theme-alpine"
+      style="height: 75vh"
+      :columnDefs="columnDefs"
+      :rowData="rowData"
+  ></ag-grid-vue>
+
+</template>
+
+<style scoped>
+</style>

--- a/src/main/resources/frontend/src/views/AdminView/Students.vue
+++ b/src/main/resources/frontend/src/views/AdminView/Students.vue
@@ -2,7 +2,7 @@
 import { AgGridVue } from 'ag-grid-vue3';
 import type { ValueGetterParams, CellClickedEvent } from 'ag-grid-community'
 import 'ag-grid-community/styles/ag-grid.css';
-import "ag-grid-community/styles/ag-theme-alpine.css";
+import "ag-grid-community/styles/ag-theme-quartz.css";
 import {onMounted, reactive, ref} from "vue";
 import {usersGet} from "@/services/adminService";
 import PopUp from "@/components/PopUp.vue";
@@ -48,7 +48,7 @@ const rowData = reactive({
 
 <template>
   <ag-grid-vue
-      class="ag-theme-alpine"
+      class="ag-theme-quartz"
       style="height: 75vh"
       :columnDefs="columnDefs"
       :rowData="rowData.value"

--- a/src/main/resources/frontend/src/views/AdminView/Students.vue
+++ b/src/main/resources/frontend/src/views/AdminView/Students.vue
@@ -4,17 +4,16 @@ import type { ValueGetterParams, CellClickedEvent } from 'ag-grid-community'
 import 'ag-grid-community/styles/ag-grid.css';
 import "ag-grid-community/styles/ag-theme-alpine.css";
 import {onMounted, reactive, ref} from "vue";
-import {submissionsForUserGet, usersGet} from "@/services/adminService";
+import {usersGet} from "@/services/adminService";
 import PopUp from "@/components/PopUp.vue";
 import type {User} from "@/types/types";
 import StudentInfo from "@/views/AdminView/StudentInfo.vue";
 
-let selectedStudent = ref<User | null>(null);
+const selectedStudent = ref<User | null>(null);
 
 const cellClickHandler = (event: CellClickedEvent) => {
   let findResult = studentData.find(user => user.netId === event.data.netID)
   selectedStudent.value = findResult || null; // Setting selected student opens a popup
-  console.log(selectedStudent)
 }
 
 let studentData: User[] = [];
@@ -32,7 +31,6 @@ onMounted(async () => {
         }
     )
   })
-  console.log(dataToShow)
   rowData.value = dataToShow
 })
 
@@ -43,7 +41,7 @@ const columnDefs = reactive([
       return '<a href="' + params.data.github + '" target="_blank">' + params.data.github + '</a>'
     }}
 ])
-let rowData = reactive({
+const rowData = reactive({
   value: []
 })
 </script>

--- a/src/main/resources/frontend/src/views/AdminView/Students.vue
+++ b/src/main/resources/frontend/src/views/AdminView/Students.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { AgGridVue } from 'ag-grid-vue3';
+import type { ValueGetterParams } from 'ag-grid-community'
 import 'ag-grid-community/styles/ag-grid.css';
 import "ag-grid-community/styles/ag-theme-alpine.css";
 import {onMounted, reactive} from "vue";
@@ -8,7 +9,9 @@ import {usersGet} from "@/services/adminService";
 const columnDefs = reactive([
         { headerName: "Name", field: 'name', sortable: true, filter: true},
         { headerName: "BYU netID", field: "netID", sortable: true, filter: true},
-        { headerName: "Github URL", field: "github", flex:1, sortable: false, filter: true}
+        { headerName: "Github URL", field: "github", flex:1, sortable: false, filter: true, cellRenderer: function(params: ValueGetterParams) {
+          return '<a href="' + params.data.github + '" target="_blank">' + params.data.github + '</a>'
+          }}
       ])
 let rowData = reactive({
   value: []

--- a/src/main/resources/frontend/src/views/AdminView/Students.vue
+++ b/src/main/resources/frontend/src/views/AdminView/Students.vue
@@ -35,10 +35,10 @@ onMounted(async () => {
 })
 
 const columnDefs = reactive([
-  { headerName: "Student Name", field: 'name', sortable: true, filter: true, onCellClicked: cellClickHandler },
-  { headerName: "BYU netID", field: "netID", sortable: true, filter: true, onCellClicked: cellClickHandler },
-  { headerName: "Github Repo URL", field: "github", flex:1, sortable: false, filter: true, cellRenderer: function(params: ValueGetterParams) {
-      return '<a href="' + params.data.github + '" target="_blank">' + params.data.github + '</a>'
+  { headerName: "Student Name", field: 'name', flex: 2, sortable: true, filter: true, onCellClicked: cellClickHandler },
+  { headerName: "BYU netID", field: "netID", flex: 1, sortable: true, filter: true, onCellClicked: cellClickHandler },
+  { headerName: "Github Repo URL", field: "github", flex: 5, sortable: false, filter: true, cellRenderer: function(params: ValueGetterParams) {
+      return '<a id="repo-link" href="' + params.data.github + '" target="_blank">' + params.data.github + '</a>'
     }}
 ])
 const rowData = reactive({
@@ -63,4 +63,5 @@ const rowData = reactive({
 </template>
 
 <style scoped>
+
 </style>

--- a/src/main/resources/frontend/src/views/AdminView/Students.vue
+++ b/src/main/resources/frontend/src/views/AdminView/Students.vue
@@ -2,33 +2,34 @@
 import { AgGridVue } from 'ag-grid-vue3';
 import 'ag-grid-community/styles/ag-grid.css';
 import "ag-grid-community/styles/ag-theme-alpine.css";
+import {onMounted, reactive} from "vue";
+import {usersGet} from "@/services/adminService";
 
-// eslint-disable-next-line vue/no-export-in-script-setup
-const columnDefs = [
-        { headerName: "Name", field: 'name'},
-        { headerName: "BYU netID", field: "netID"},
-        { headerName: "Github URL", field: "github", flex:1}
-      ]
-const rowData = [
-        {name: "Roger McGee", netID: "rogerm", github: "http://girthagk.com"},
-        {name: "Steve McGee", netID: "stevem", github: "http://github.com"},
-        {name: "Roger McGee", netID: "rogerm", github: "http://github.com"},
-        {name: "Steve McGee", netID: "stevem", github: "http://github.com"},
-        {name: "Roger McGee", netID: "rogerm", github: "http://github.com"},
-        {name: "Steve McGee", netID: "stevem", github: "http://github.com"},
-        {name: "Roger McGee", netID: "rogerm", github: "http://github.com"},
-        {name: "Steve McGee", netID: "stevem", github: "http://github.com"},
-        {name: "Roger McGee", netID: "rogerm", github: "http://github.com"},
-        {name: "Steve McGee", netID: "stevem", github: "http://github.comasdfghdfgdhdsasfgdfhfjfrewrtyhgftryhgfd"},
-        {name: "Roger McGee", netID: "rogerm", github: "http://github.com"},
-        {name: "Steve McGee", netID: "stevem", github: "http://github.com"},
-        {name: "Roger McGee", netID: "rogerm", github: "http://github.com"},
-        {name: "Steve McGee", netID: "stevem", github: "http://github.com"},
-        {name: "Roger McGee", netID: "rogerm", github: "http://github.com"},
-        {name: "Steve McGee", netID: "stevem", github: "http://github.com"},
-        {name: "Roger McGee", netID: "rogerm", github: "http://github.com"},
-        {name: "Steve McGee", netID: "stevem", github: "http://github.com"},
-      ]
+const columnDefs = reactive([
+        { headerName: "Name", field: 'name', sortable: true, filter: true},
+        { headerName: "BYU netID", field: "netID", sortable: true, filter: true},
+        { headerName: "Github URL", field: "github", flex:1, sortable: false, filter: true}
+      ])
+let rowData = reactive({
+  value: []
+})
+
+onMounted(async () => {
+  const userData = await usersGet();
+  const studentData = userData.filter(user => user.role == "STUDENT") // get rid of users that aren't students
+  var dataToShow: any = []
+  studentData.forEach(student => {
+    dataToShow.push(
+        {
+          name: student.firstName + " " + student.lastName,
+          netID: student.netId,
+          github: student.repoUrl
+        }
+    )
+  })
+  console.log(dataToShow)
+  rowData.value = dataToShow
+})
 </script>
 
 <template>
@@ -36,7 +37,7 @@ const rowData = [
       class="ag-theme-alpine"
       style="height: 75vh"
       :columnDefs="columnDefs"
-      :rowData="rowData"
+      :rowData="rowData.value"
   ></ag-grid-vue>
 
 </template>

--- a/src/main/resources/frontend/yarn.lock
+++ b/src/main/resources/frontend/yarn.lock
@@ -582,6 +582,18 @@ acorn@^8.9.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
   integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
 
+ag-grid-community@31.1.1:
+  version "31.1.1"
+  resolved "https://registry.yarnpkg.com/ag-grid-community/-/ag-grid-community-31.1.1.tgz#212fc3e358d4be1865bc4618f6d0d865faaed385"
+  integrity sha512-tiQZ7VQ07yJScTMIQpaYoUMPgiyXMwYDcwTxe4riRrcYGTg0e258XEihoPUZFejR60P1fYWMxdJaR2JUnyhGrg==
+
+ag-grid-vue3@^31.1.1:
+  version "31.1.1"
+  resolved "https://registry.yarnpkg.com/ag-grid-vue3/-/ag-grid-vue3-31.1.1.tgz#0382632cf521138c532b48c9b985c3951d69e788"
+  integrity sha512-GjR4/6JUWQ0VsdmcxSN5ks1vH+wB7lLjX1CbskPqNfD69/fb9l7Eg2oGAgqNJo8b87W87jzhg9RguOx5bDpsZQ==
+  dependencies:
+    ag-grid-community "31.1.1"
+
 ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"


### PR DESCRIPTION
There is now a new tab: "students"

This tab shows a list of all students from the server database, their netID, and a clickable Github URL. Clicking on either the student's name or netID will open up a pop-up window with all of their submissions. (Which you can then open another pop-up in)