### PR TITLE
Add compile options to tsconfig.json file

### DIFF
--- a/src/main/resources/frontend/tsconfig.json
+++ b/src/main/resources/frontend/tsconfig.json
@@ -7,5 +7,11 @@
     {
       "path": "./tsconfig.app.json"
     }
-  ]
+  ],
+  "compilerOptions": {
+    "target": "es2021",
+    "strict": true,
+    "module": "es2015",
+    "moduleResolution": "node"
+  }
 }


### PR DESCRIPTION
Per the [Vue typescript documentation](https://v2.vuejs.org/v2/guide/typescript).

## Overview
By defining the TSconfig options, we should now be allowed to target more recent version of javascript. 

## Typescript Target Version
While the recommended `target` is "es5", I set it forward to "es2021" to be more recent. I don't expect us to be highly concerned with maximizing browser compatibility, and "es2021" is plenty reasonable to use. Honestly, we could probably set it to "es2023".

See the CanIUse for [ES2021](https://caniuse.com/?search=es2021) and for the specific features within [ES2021](https://caniuse.com/?feats=mdn-javascript_builtins_string_replaceall,mdn-javascript_builtins_promise_any,mdn-javascript_builtins_weakref,mdn-javascript_operators_logical_or_assignment,mdn-javascript_operators_logical_and_assignment,mdn-javascript_operators_nullish_coalescing_assignment,mdn-javascript_grammar_numeric_separators,mdn-javascript_builtins_finalizationregistry).
