### PR TITLE
229 backend verify that tests exist before attempting to compile

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/PhaseThreeGrader.java
+++ b/src/main/java/edu/byu/cs/autograder/PhaseThreeGrader.java
@@ -43,7 +43,7 @@ public class PhaseThreeGrader extends PassoffTestGrader {
         new TestHelper().compileTests(
                 stageRepo,
                 "server",
-                new File(stageRepo, "server/src/test/java"),
+                new File(stageRepo, "server/src/test/java/serviceTests"),
                 stagePath,
                 excludedTests);
 

--- a/src/main/java/edu/byu/cs/autograder/TestHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/TestHelper.java
@@ -53,7 +53,7 @@ public class TestHelper {
      * @param excludedTests A set of tests to exclude from compilation. Can be directory or file names
      */
     void compileTests(File stageRepoPath, String module, File testsLocation, String stagePath, Set<String> excludedTests) {
-
+        if(!testsLocation.exists()) return;
         // remove any existing tests
         FileUtils.removeDirectory(new File(stagePath + "/tests"));
 


### PR DESCRIPTION
This commit requires tests exist before compiling (having no tests just means getting a 0 for that rubric item). This also requires phase 3 tests be in the serviceTests folder