### PR TITLE
Load only 25 Submissions initially

### DIFF
--- a/src/main/java/edu/byu/cs/controller/SubmissionController.java
+++ b/src/main/java/edu/byu/cs/controller/SubmissionController.java
@@ -196,7 +196,9 @@ public class SubmissionController {
     };
 
     public static Route latestSubmissionsGet = (req, res) -> {
-        Collection<Submission> submissions = DaoService.getSubmissionDao().getAllLatestSubmissions();
+        String countString = req.params(":count");
+        int count = countString == null ? -1 : Integer.parseInt(countString); // if they don't give a count, set it to -1, which gets all latest submissions
+        Collection<Submission> submissions = DaoService.getSubmissionDao().getAllLatestSubmissions(count);
 
         res.status(200);
         res.type("application/json");

--- a/src/main/java/edu/byu/cs/dataAccess/SubmissionDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/SubmissionDao.java
@@ -32,11 +32,19 @@ public interface SubmissionDao {
     Collection<Submission> getSubmissionsForUser(String netId);
 
     /**
-     * Gets all submissions for the given phase
+     * Gets all latest submissions
      *
-     * @return all submissions for the given phase
+     * @return all latest submissions
      */
     Collection<Submission> getAllLatestSubmissions();
+
+    /**
+     * Gets the X most recent latest submissions
+     *
+     * @param batchSize defines how many submissions to return. Set batchSize to -1 to get All submissions
+     * @return the most recent X submissions
+     */
+    Collection<Submission> getAllLatestSubmissions(int batchSize);
 
     /**
      * Removes all submissions for the given netId

--- a/src/main/java/edu/byu/cs/dataAccess/SubmissionDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/SubmissionDao.java
@@ -41,7 +41,7 @@ public interface SubmissionDao {
     /**
      * Gets the X most recent latest submissions
      *
-     * @param batchSize defines how many submissions to return. Set batchSize to -1 to get All submissions
+     * @param batchSize defines how many submissions to return. Set batchSize to a negative int to get All submissions
      * @return the most recent X submissions
      */
     Collection<Submission> getAllLatestSubmissions(int batchSize);

--- a/src/main/java/edu/byu/cs/dataAccess/memory/SubmissionMemoryDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/memory/SubmissionMemoryDao.java
@@ -4,7 +4,6 @@ import edu.byu.cs.dataAccess.SubmissionDao;
 import edu.byu.cs.model.Phase;
 import edu.byu.cs.model.Submission;
 
-import java.time.Instant;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -57,7 +56,7 @@ public class SubmissionMemoryDao implements SubmissionDao {
                 }
             });
 
-            batchSize += -1;
+            batchSize -= 1;
             if (batchSize == 0) { break; }
         }
 

--- a/src/main/java/edu/byu/cs/dataAccess/sql/SubmissionSqlDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/sql/SubmissionSqlDao.java
@@ -95,8 +95,8 @@ public class SubmissionSqlDao implements SubmissionDao {
                             )
                             ORDER BY timestamp DESC
                             """ +
-                            (batchSize == -1 ? "" : "LIMIT ?"));
-            if (batchSize != -1) {
+                            (batchSize < 0 ? "LIMIT ?" : ""));
+            if (batchSize < 0) {
                 statement.setInt(1, batchSize);
             }
             return getSubmissionsFromQuery(statement);

--- a/src/main/java/edu/byu/cs/dataAccess/sql/SubmissionSqlDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/sql/SubmissionSqlDao.java
@@ -78,6 +78,11 @@ public class SubmissionSqlDao implements SubmissionDao {
 
     @Override
     public Collection<Submission> getAllLatestSubmissions() {
+        return getAllLatestSubmissions(-1);
+    }
+
+    @Override
+    public Collection<Submission> getAllLatestSubmissions(int batchSize) {
         try (var connection = SqlDb.getConnection()) {
             PreparedStatement statement = connection.prepareStatement(
                     """
@@ -88,7 +93,12 @@ public class SubmissionSqlDao implements SubmissionDao {
                                 FROM submission
                                 GROUP BY net_id, phase
                             )
-                            """);
+                            ORDER BY timestamp DESC
+                            """ +
+                            (batchSize == -1 ? "" : "LIMIT ?"));
+            if (batchSize != -1) {
+                statement.setInt(1, batchSize);
+            }
             return getSubmissionsFromQuery(statement);
 
         } catch (Exception e) {

--- a/src/main/java/edu/byu/cs/dataAccess/sql/SubmissionSqlDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/sql/SubmissionSqlDao.java
@@ -95,8 +95,8 @@ public class SubmissionSqlDao implements SubmissionDao {
                             )
                             ORDER BY timestamp DESC
                             """ +
-                            (batchSize < 0 ? "LIMIT ?" : ""));
-            if (batchSize < 0) {
+                            (batchSize >= 0 ? "LIMIT ?" : ""));
+            if (batchSize >= 0) {
                 statement.setInt(1, batchSize);
             }
             return getSubmissionsFromQuery(statement);

--- a/src/main/java/edu/byu/cs/server/Server.java
+++ b/src/main/java/edu/byu/cs/server/Server.java
@@ -65,6 +65,8 @@ public class Server {
 
                 get("/submissions/latest", latestSubmissionsGet);
 
+                get("/submissions/latest/:count", latestSubmissionsGet);
+
                 get("/test_mode", testModeGet);
 
                 get("/submissions/active", submissionsActiveGet);

--- a/src/main/resources/frontend/src/services/adminService.ts
+++ b/src/main/resources/frontend/src/services/adminService.ts
@@ -66,9 +66,10 @@ export const userPatch = async (user: UserPatch)=> {
     }
 }
 
-export const submissionsLatestGet = async (): Promise<Submission[]> => {
+export const submissionsLatestGet = async (batchSize?: number): Promise<Submission[]> => {
+    batchSize = batchSize ? batchSize : -1
     try {
-        const response = await fetch(useAppConfigStore().backendUrl + '/api/admin/submissions/latest', {
+        const response = await fetch(useAppConfigStore().backendUrl + '/api/admin/submissions/latest/' + batchSize, {
             method: 'GET',
             credentials: 'include'
         });

--- a/src/main/resources/frontend/src/views/AdminView/SubmissionsView.vue
+++ b/src/main/resources/frontend/src/views/AdminView/SubmissionsView.vue
@@ -20,25 +20,36 @@ import {nameFromNetId} from "@/utils/utils";
 
 const selectedSubmission = ref<Submission | null>(null);
 const selectedStudent = ref<User | null>(null);
+const DEFAULT_SUBMISSIONS_TO_LOAD = 25;
+let allSubmissionsLoaded = false;
 
 onMounted(async () => {
-  const submissionsData = await submissionsLatestGet();
-  submissionsData.sort((a, b) => b.timestamp.localeCompare(a.timestamp)) // Sort by timestamp descending
+  const submissionsData = await submissionsLatestGet(DEFAULT_SUBMISSIONS_TO_LOAD);
+  //submissionsData.sort((a, b) => b.timestamp.localeCompare(a.timestamp)) // Sort by timestamp descending
+  loadSubmissionsToTable(submissionsData)
+})
+
+const loadAllSubmissions = async () => {
+  loadSubmissionsToTable( await submissionsLatestGet() )
+  allSubmissionsLoaded = true;
+}
+
+const loadSubmissionsToTable = (submissionsData : Submission[]) => {
   var dataToShow: any = []
   submissionsData.forEach(submission => {
     dataToShow.push( {
-      name: nameFromNetId(submission.netId),
-      phase: submission.phase,
-      timestamp: submission.timestamp,
-      score: submission.score,
-      notes: submission.notes,
-      netId: submission.netId,
-      submission: submission
-      }
+          name: nameFromNetId(submission.netId),
+          phase: submission.phase,
+          timestamp: submission.timestamp,
+          score: submission.score,
+          notes: submission.notes,
+          netId: submission.netId,
+          submission: submission
+        }
     )
   })
   rowData.value = dataToShow
-})
+}
 
 const notesCellClicked = (event: CellClickedEvent) => {
   selectedSubmission.value = event.data.submission
@@ -64,11 +75,20 @@ const rowData = reactive({
 <template>
   <ag-grid-vue
       class="ag-theme-quartz"
-      style="height: 75vh"
+      style="height: 65vh"
       :columnDefs="columnDefs"
       :rowData="rowData.value"
       :defaultColDef="standardColSettings"
   ></ag-grid-vue>
+
+  <div class="container">
+    <p v-if="allSubmissionsLoaded">All latest submissions are loaded</p>
+    <p v-else>Currently only the {{DEFAULT_SUBMISSIONS_TO_LOAD}} most recent latest submssions are loaded</p>
+    <button id="loadMore" @click="loadAllSubmissions">
+      <span v-if="allSubmissionsLoaded">Reload submissions list</span>
+      <span v-else>Load all latest submissions</span>
+    </button>
+  </div>
 
   <PopUp
       v-if="selectedSubmission"
@@ -85,4 +105,18 @@ const rowData = reactive({
 </template>
 
 <style scoped>
+.container {
+  padding: 10px;
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  margin: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #f2f2f2;
+  align-items: center;
+}
+
+#loadMore {
+  font-size: medium;
+}
 </style>

--- a/src/main/resources/frontend/src/views/AdminView/SubmissionsView.vue
+++ b/src/main/resources/frontend/src/views/AdminView/SubmissionsView.vue
@@ -25,7 +25,6 @@ let allSubmissionsLoaded = false;
 
 onMounted(async () => {
   const submissionsData = await submissionsLatestGet(DEFAULT_SUBMISSIONS_TO_LOAD);
-  //submissionsData.sort((a, b) => b.timestamp.localeCompare(a.timestamp)) // Sort by timestamp descending
   loadSubmissionsToTable(submissionsData)
 })
 


### PR DESCRIPTION
The Submissions View now only loads the most recent 25 latest submissions. (Latest submission meaning the most recent submission per student per phase). There is now a button at the bottom to load in all latest submissions.

This was done by adding an optional batchSize parameter to the getAllLatestSubmissions() on the DAO that uses a LIMIT statement as suggested by @frozenfrank. 

The specific amount of submissions that is initially loaded is determined by a const in the submissions view, so is easily adjustable.