### PR TITLE
fix score calculation

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/score/Scorer.java
+++ b/src/main/java/edu/byu/cs/autograder/score/Scorer.java
@@ -92,7 +92,7 @@ public class Scorer {
 
     private float calculateScoreWithLatePenalty(Rubric rubric, int numDaysLate) throws GradingException {
         float score = getScore(rubric);
-        score -= numDaysLate * PER_DAY_LATE_PENALTY;
+        score *= 1 - (numDaysLate * PER_DAY_LATE_PENALTY);
         if (score < 0) score = 0;
         return score;
     }


### PR DESCRIPTION
This fixes the displayed grade percentage. Currently, the calculation just drops the percentage by 10*x%, where x is the number of days late. This leads to displaying (not grading, grading works correctly) incorrect scores, like 58% instead of 54% for phase 1 extra credit or 33.97% instead of 41.98% for my branch without any phase 3 unit tests and a dock on code quality