### PR TITLE
fix admin submission to not call canvas

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/score/Scorer.java
+++ b/src/main/java/edu/byu/cs/autograder/score/Scorer.java
@@ -40,12 +40,17 @@ public class Scorer {
         rubric = CanvasUtils.decimalScoreToPoints(gradingContext.phase(), rubric);
         rubric = annotateRubric(rubric);
 
+        // skip penalties if running in admin mode
+        if (gradingContext.admin()) {
+            return saveResults(rubric, numCommits, 0, getScore(rubric), "");
+        }
+
         int daysLate = new LateDayCalculator().calculateLateDays(gradingContext.phase(), gradingContext.netId());
         float thisScore = calculateScoreWithLatePenalty(rubric, daysLate);
         Submission thisSubmission;
 
         // prevent score from being saved to canvas if it will lower their score
-        if(rubric.passed() && !gradingContext.admin()) {
+        if(rubric.passed()) {
             float highestScore = getCanvasScore();
 
             // prevent score from being saved to canvas if it will lower their score


### PR DESCRIPTION
For some reason #256 had a bug that only appeared on the production server where an admin submission wouldn't complete because it tried calling canvas with the admin's netID. This shouldn't have been happening, and it didn't happen during testing, even after the merges. In theory this PR should fix it, by moving the admin-mode check to the beginning of the Scorer call.