### PR TITLE
225 run quality checks independent of submitting a phase

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/database/DatabaseHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/database/DatabaseHelper.java
@@ -73,7 +73,7 @@ public class DatabaseHelper {
                 os.flush();
             }
         } catch (IOException e) {
-            throw new GradingException("Could add db config", e);
+            throw new GradingException("Could not add db config", e);
         }
     }
 

--- a/src/main/java/edu/byu/cs/autograder/score/Scorer.java
+++ b/src/main/java/edu/byu/cs/autograder/score/Scorer.java
@@ -40,7 +40,7 @@ public class Scorer {
         rubric = annotateRubric(rubric);
 
         // skip penalties if running in admin mode
-        if (gradingContext.admin()) {
+        if (gradingContext.admin() || !PhaseUtils.isPhaseGraded(gradingContext.phase())) {
             return saveResults(rubric, numCommits, 0, getScore(rubric), "");
         }
 

--- a/src/main/java/edu/byu/cs/controller/SubmissionController.java
+++ b/src/main/java/edu/byu/cs/controller/SubmissionController.java
@@ -139,7 +139,7 @@ public class SubmissionController {
         }
 
         if (!Arrays.asList(0, 1, 3, 4, 5, 6, 42).contains(request.phase())) {
-            halt(400, "Valid phases are 0, 1, 3, 4, 5, or 6");
+            halt(400, "Valid phases are 0, 1, 3, 4, 5, 6, or 42");
             return null;
         }
 

--- a/src/main/java/edu/byu/cs/controller/SubmissionController.java
+++ b/src/main/java/edu/byu/cs/controller/SubmissionController.java
@@ -138,7 +138,7 @@ public class SubmissionController {
             return null;
         }
 
-        if (!Arrays.asList(0, 1, 3, 4, 5, 6).contains(request.phase())) {
+        if (!Arrays.asList(0, 1, 3, 4, 5, 6, 42).contains(request.phase())) {
             halt(400, "Valid phases are 0, 1, 3, 4, 5, or 6");
             return null;
         }

--- a/src/main/java/edu/byu/cs/controller/netmodel/GradeRequest.java
+++ b/src/main/java/edu/byu/cs/controller/netmodel/GradeRequest.java
@@ -4,6 +4,7 @@ import edu.byu.cs.model.Phase;
 
 public record GradeRequest(int phase, String repoUrl) {
     public Phase getPhase() {
+        if(phase == 42) return Phase.Quality;
         return Phase.valueOf("Phase" + phase);
     }
 }

--- a/src/main/java/edu/byu/cs/model/Phase.java
+++ b/src/main/java/edu/byu/cs/model/Phase.java
@@ -7,4 +7,5 @@ public enum Phase {
     Phase4,
     Phase5,
     Phase6,
+    Quality
 }

--- a/src/main/java/edu/byu/cs/util/PhaseUtils.java
+++ b/src/main/java/edu/byu/cs/util/PhaseUtils.java
@@ -175,4 +175,11 @@ public class PhaseUtils {
             case Quality -> null;
         };
     }
+
+    public static boolean isPhaseGraded(Phase phase) {
+        return switch (phase) {
+            case Phase0, Phase1, Phase3, Phase4, Phase5, Phase6 -> true;
+            case Quality -> false;
+        };
+    }
 }

--- a/src/main/java/edu/byu/cs/util/PhaseUtils.java
+++ b/src/main/java/edu/byu/cs/util/PhaseUtils.java
@@ -66,6 +66,7 @@ public class PhaseUtils {
             case "4" -> Phase.Phase4;
             case "5" -> Phase.Phase5;
             case "6" -> Phase.Phase6;
+            case "42" -> Phase.Quality;
             default -> null;
         };
     }

--- a/src/main/java/edu/byu/cs/util/PhaseUtils.java
+++ b/src/main/java/edu/byu/cs/util/PhaseUtils.java
@@ -25,7 +25,7 @@ public class PhaseUtils {
      */
     public static Phase getPreviousPhase(Phase phase) {
         return switch (phase) {
-            case Phase0 -> null;
+            case Phase0, Quality -> null;
             case Phase1 -> Phase.Phase0;
             case Phase3 -> Phase.Phase1;
             case Phase4 -> Phase.Phase3;
@@ -48,6 +48,7 @@ public class PhaseUtils {
             case Phase4 -> "4";
             case Phase5 -> "5";
             case Phase6 -> "6";
+            case Quality -> "Quality";
         };
     }
 
@@ -83,6 +84,7 @@ public class PhaseUtils {
             case Phase4 -> PHASE4_ASSIGNMENT_NUMBER;
             case Phase5 -> PHASE5_ASSIGNMENT_NUMBER;
             case Phase6 -> PHASE6_ASSIGNMENT_NUMBER;
+            case Quality -> 0;
         };
     }
 
@@ -98,6 +100,7 @@ public class PhaseUtils {
             case Phase0, Phase1, Phase4, Phase5 -> 125.0F;
             case Phase3 -> 180.0F;
             case Phase6 -> 155.0F;
+            case Quality -> 0.0F;
         };
     }
 
@@ -106,14 +109,14 @@ public class PhaseUtils {
             case Phase0 -> Set.of("passoffTests.chessTests", "passoffTests.chessTests.chessPieceTests");
             case Phase1 -> Set.of("passoffTests.chessTests", "passoffTests.chessTests.chessExtraCredit");
             case Phase3, Phase4 -> Set.of("passoffTests.serverTests");
-            case Phase5 -> throw new GradingException("No passoff tests for this phase");
+            case Phase5, Quality -> throw new GradingException("No passoff tests for this phase");
             case Phase6 -> throw new GradingException("Not implemented");
         };
     }
 
     public static Set<String> unitTestPackagesToTest(Phase phase) throws GradingException {
         return switch (phase) {
-            case Phase0, Phase1, Phase6 -> throw new GradingException("No unit tests for this phase");
+            case Phase0, Phase1, Phase6, Quality -> throw new GradingException("No unit tests for this phase");
             case Phase3 -> Set.of("serviceTests");
             case Phase4 -> Set.of("dataAccessTests");
             case Phase5 -> Set.of("clientTests");
@@ -122,7 +125,7 @@ public class PhaseUtils {
 
     public static String unitTestCodeUnderTest(Phase phase) throws GradingException {
         return switch (phase) {
-            case Phase0, Phase1, Phase6 -> throw new GradingException("No unit tests for this phase");
+            case Phase0, Phase1, Phase6, Quality -> throw new GradingException("No unit tests for this phase");
             case Phase3 -> "service";
             case Phase4 -> "dao";
             case Phase5 -> "server facade";
@@ -131,7 +134,7 @@ public class PhaseUtils {
 
     public static int minUnitTests(Phase phase) throws GradingException {
         return switch (phase) {
-            case Phase0, Phase1, Phase6 -> throw new GradingException("No unit tests for this phase");
+            case Phase0, Phase1, Phase6, Quality -> throw new GradingException("No unit tests for this phase");
             case Phase3 -> 13;
             case Phase4 -> 18;
             case Phase5 -> 12;
@@ -159,6 +162,7 @@ public class PhaseUtils {
                 case PASSOFF_TESTS, QUALITY -> throw new GradingException(String.format("No %s item for this phase", type));
             };
             case Phase6 -> throw new GradingException("Phase 6 not implemented yet");
+            case Quality -> throw new GradingException("Not graded");
         };
     }
 
@@ -168,6 +172,7 @@ public class PhaseUtils {
             case Phase0, Phase1 -> "shared";
             case Phase3, Phase4, Phase6 -> "server";
             case Phase5 -> "client";
+            case Quality -> null;
         };
     }
 }

--- a/src/main/resources/frontend/src/types/types.ts
+++ b/src/main/resources/frontend/src/types/types.ts
@@ -1,4 +1,4 @@
-export type Phase = '0' | '1' | '3' | '4' | '5' | '6';
+export type Phase = '0' | '1' | '3' | '4' | '5' | '6' | '42';
 
 export type TestNode = {
     testName: string,

--- a/src/main/resources/frontend/src/views/AdminView/SubmissionsView.vue
+++ b/src/main/resources/frontend/src/views/AdminView/SubmissionsView.vue
@@ -114,6 +114,7 @@ const adminSubmit = async (phase: Phase) => {
         <a @click="adminSubmit('3')">Phase 3</a>
         <a @click="adminSubmit('4')">Phase 4</a>
         <a @click="adminSubmit('5')">Phase 5</a>
+        <a @click="adminSubmit('42')">Quality</a>
       </template>
     </Dropdown>
   </div>

--- a/src/main/resources/frontend/src/views/HomeView.vue
+++ b/src/main/resources/frontend/src/views/HomeView.vue
@@ -38,7 +38,7 @@ onMounted(async () => {
     </Tab>
     <Tab title="Phase 6" disabled>Phase 6 content</Tab>
     <Tab title="Quality">
-      <PhaseView phase-title="Run only code quality (not graded)" phaseDescription="Use this to run just the code quality without running test cases. THIS DOES NOT AFFECT GRADES" phase="42" />
+      <PhaseView phase-title="Run only code quality (not graded)" phaseDescription="Use this to run just the code quality without running test cases. This is NOT graded and will NOT be submitted to Canvas." phase="42" />
     </Tab>
   </Tabs>
 </template>

--- a/src/main/resources/frontend/src/views/HomeView.vue
+++ b/src/main/resources/frontend/src/views/HomeView.vue
@@ -37,6 +37,9 @@ onMounted(async () => {
       <PhaseView phase-title="Phase 5: Chess Client" phaseDescription="For this phase you must pass all of the unit tests that you were required to write." phase="5" />
     </Tab>
     <Tab title="Phase 6" disabled>Phase 6 content</Tab>
+    <Tab title="Quality">
+      <PhaseView phase-title="Run only code quality" phaseDescription="Use this to run just the code quality without running test cases" phase="42" />
+    </Tab>
   </Tabs>
 </template>
 

--- a/src/main/resources/frontend/src/views/HomeView.vue
+++ b/src/main/resources/frontend/src/views/HomeView.vue
@@ -38,7 +38,7 @@ onMounted(async () => {
     </Tab>
     <Tab title="Phase 6" disabled>Phase 6 content</Tab>
     <Tab title="Quality">
-      <PhaseView phase-title="Run only code quality" phaseDescription="Use this to run just the code quality without running test cases" phase="42" />
+      <PhaseView phase-title="Run only code quality" phaseDescription="Use this to run just the code quality without running test cases. THIS DOES NOT AFFECT GRADES" phase="42" />
     </Tab>
   </Tabs>
 </template>

--- a/src/main/resources/frontend/src/views/HomeView.vue
+++ b/src/main/resources/frontend/src/views/HomeView.vue
@@ -38,7 +38,7 @@ onMounted(async () => {
     </Tab>
     <Tab title="Phase 6" disabled>Phase 6 content</Tab>
     <Tab title="Quality">
-      <PhaseView phase-title="Run only code quality" phaseDescription="Use this to run just the code quality without running test cases. THIS DOES NOT AFFECT GRADES" phase="42" />
+      <PhaseView phase-title="Run only code quality (not graded)" phaseDescription="Use this to run just the code quality without running test cases. THIS DOES NOT AFFECT GRADES" phase="42" />
     </Tab>
   </Tabs>
 </template>


### PR DESCRIPTION
This adds the ability to run just the quality checker without any phases. 

Must add something like
INSERT INTO autograder.rubric_config (phase, type, category, criteria, points) VALUES ('Quality', 'QUALITY', 'Code Quality', 'Chess Code Quality Rubric (see GitHub)', 30);
to the database for this to work.

closes #225