### PR TITLE
Streamline phase configuration

### DIFF
--- a/src/main/java/edu/byu/cs/model/Phase.java
+++ b/src/main/java/edu/byu/cs/model/Phase.java
@@ -3,6 +3,8 @@ package edu.byu.cs.model;
 import java.util.Map;
 import java.util.Set;
 
+import static edu.byu.cs.model.Rubric.RubricType.*;
+
 public enum Phase {
 
     // FIXME: Load this list of data dynamically from a configuration table #156
@@ -13,7 +15,7 @@ public enum Phase {
             true,
             null,
             880445,
-            Map.of(Rubric.RubricType.PASSOFF_TESTS, "_1958"),
+            Map.of(PASSOFF_TESTS, "_1958"),
             -1,
             "shared",
             null,
@@ -26,7 +28,7 @@ public enum Phase {
             true,
             Phase0,
             880446,
-            Map.of(Rubric.RubricType.PASSOFF_TESTS, "_1958"),
+            Map.of(PASSOFF_TESTS, "_1958"),
             -1,
             "shared",
             null,
@@ -40,9 +42,9 @@ public enum Phase {
             Phase1,
             880448,
             Map.of(
-                Rubric.RubricType.PASSOFF_TESTS,  "_5202",
-                Rubric.RubricType.UNIT_TESTS,  "90344_776",
-                Rubric.RubricType.QUALITY,  "_3003"
+                PASSOFF_TESTS,  "_5202",
+                UNIT_TESTS,  "90344_776",
+                QUALITY,  "_3003"
             ),
             13,
             "server",
@@ -57,8 +59,8 @@ public enum Phase {
             Phase3,
             880449,
             Map.of(
-                Rubric.RubricType.PASSOFF_TESTS,  "_2614",
-                Rubric.RubricType.UNIT_TESTS,  "_930"
+                PASSOFF_TESTS,  "_2614",
+                UNIT_TESTS,  "_930"
             ),
             18,
             "server",
@@ -72,7 +74,7 @@ public enum Phase {
             true,
             Phase4,
             880450,
-            Map.of(Rubric.RubricType.UNIT_TESTS,  "_8849"),
+            Map.of(UNIT_TESTS,  "_8849"),
             12,
             "client",
             "server facade",

--- a/src/main/java/edu/byu/cs/model/Phase.java
+++ b/src/main/java/edu/byu/cs/model/Phase.java
@@ -1,11 +1,143 @@
 package edu.byu.cs.model;
 
+import java.util.Map;
+import java.util.Set;
+
 public enum Phase {
-    Phase0,
-    Phase1,
-    Phase3,
-    Phase4,
-    Phase5,
-    Phase6,
-    Quality
+
+    // FIXME: Load this list of data dynamically from a configuration table #156
+
+    Phase0(
+            "0",
+            "0",
+            true,
+            null,
+            880445,
+            Map.of(Rubric.RubricType.PASSOFF_TESTS, "_1958"),
+            -1,
+            "shared",
+            null,
+            null,
+            Set.of("passoffTests.chessTests", "passoffTests.chessTests.chessPieceTests")
+    ),
+    Phase1(
+            "1",
+            "1",
+            true,
+            Phase0,
+            880446,
+            Map.of(Rubric.RubricType.PASSOFF_TESTS, "_1958"),
+            -1,
+            "shared",
+            null,
+            null,
+            Set.of("passoffTests.chessTests", "passoffTests.chessTests.chessExtraCredit")
+    ),
+    Phase3(
+            "3",
+            "3",
+            true,
+            Phase1,
+            880448,
+            Map.of(
+                Rubric.RubricType.PASSOFF_TESTS,  "_5202",
+                Rubric.RubricType.UNIT_TESTS,  "90344_776",
+                Rubric.RubricType.QUALITY,  "_3003"
+            ),
+            13,
+            "server",
+            "service",
+            Set.of("serviceTests"),
+            Set.of("passoffTests.serverTests")
+    ),
+    Phase4(
+            "4",
+            "4",
+            true,
+            Phase3,
+            880449,
+            Map.of(
+                Rubric.RubricType.PASSOFF_TESTS,  "_2614",
+                Rubric.RubricType.UNIT_TESTS,  "_930"
+            ),
+            18,
+            "server",
+            "dao",
+            Set.of("dataAccessTests"),
+            Set.of("passoffTests.serverTests")
+    ),
+    Phase5(
+            "5",
+            "5",
+            true,
+            Phase4,
+            880450,
+            Map.of(Rubric.RubricType.UNIT_TESTS,  "_8849"),
+            12,
+            "client",
+            "server facade",
+            Set.of("clientTests"),
+            null
+    ),
+    Phase6(
+            "6",
+            "6",
+            true,
+            Phase5,
+            880451,
+            null,
+            -1,
+            "server",
+            null,
+            null,
+            null
+    ),
+    Quality(
+            "42",
+            "Quality",
+            false,
+            null,
+            0,
+            null,
+            -1,
+            null,
+            null,
+            null,
+            null
+    );
+
+    // ## Value configuration
+
+    public final String stringValue;
+    public final String stringName;
+    public final boolean isGraded;
+    public final Phase previousPhase;
+
+    // Canvas config values
+    public final int assignmentNumber;
+    public final Map<Rubric.RubricType, String> rubricIds;
+
+    // Test configuration
+    public final int minUnitTests;
+    public final String moduleUnderTest;
+    public final String unitTestCodeUnderTest;
+    public final Set<String> unitTestPackagesToTest;
+    public final Set<String> passoffPackagesToTest;
+
+    Phase(String stringValue, String stringName, boolean isGraded, Phase previousPhase, int assignmentNumber,
+          Map<Rubric.RubricType, String> rubricIds, int minUnitTests, String moduleUnderTest,
+          String unitTestCodeUnderTest, Set<String> unitTestPackagesToTest, Set<String> passoffPackagesToTest
+    ) {
+        this.stringValue = stringValue;
+        this.stringName = stringName;
+        this.isGraded = isGraded;
+        this.previousPhase = previousPhase;
+        this.assignmentNumber = assignmentNumber;
+        this.rubricIds = rubricIds;
+        this.minUnitTests = minUnitTests;
+        this.moduleUnderTest = moduleUnderTest;
+        this.unitTestCodeUnderTest = unitTestCodeUnderTest;
+        this.unitTestPackagesToTest = unitTestPackagesToTest;
+        this.passoffPackagesToTest = passoffPackagesToTest;
+    }
 }

--- a/src/main/java/edu/byu/cs/util/PhaseUtils.java
+++ b/src/main/java/edu/byu/cs/util/PhaseUtils.java
@@ -5,7 +5,6 @@ import edu.byu.cs.model.Phase;
 import edu.byu.cs.model.Rubric;
 import org.eclipse.jgit.annotations.NonNull;
 
-import java.util.Map;
 import java.util.Set;
 
 public class PhaseUtils {

--- a/src/main/java/edu/byu/cs/util/PhaseUtils.java
+++ b/src/main/java/edu/byu/cs/util/PhaseUtils.java
@@ -3,19 +3,12 @@ package edu.byu.cs.util;
 import edu.byu.cs.autograder.GradingException;
 import edu.byu.cs.model.Phase;
 import edu.byu.cs.model.Rubric;
+import org.eclipse.jgit.annotations.NonNull;
 
+import java.util.Map;
 import java.util.Set;
 
 public class PhaseUtils {
-
-    // FIXME: dynamically get assignment numbers
-    private static final int PHASE0_ASSIGNMENT_NUMBER = 880445;
-    private static final int PHASE1_ASSIGNMENT_NUMBER = 880446;
-    private static final int PHASE3_ASSIGNMENT_NUMBER = 880448;
-    private static final int PHASE4_ASSIGNMENT_NUMBER = 880449;
-
-    private static final int PHASE5_ASSIGNMENT_NUMBER = 880450;
-    private static final int PHASE6_ASSIGNMENT_NUMBER = 880451;
 
     /**
      * Given a phase, returns the phase before it, or null.
@@ -24,14 +17,7 @@ public class PhaseUtils {
      * @return the previous phase chronologically
      */
     public static Phase getPreviousPhase(Phase phase) {
-        return switch (phase) {
-            case Phase0, Quality -> null;
-            case Phase1 -> Phase.Phase0;
-            case Phase3 -> Phase.Phase1;
-            case Phase4 -> Phase.Phase3;
-            case Phase5 -> Phase.Phase4;
-            case Phase6 -> Phase.Phase5;
-        };
+        return phase.previousPhase;
     }
 
     /**
@@ -41,15 +27,7 @@ public class PhaseUtils {
      * @return the string
      */
     public static String getPhaseAsString(Phase phase) {
-        return switch (phase) {
-            case Phase0 -> "0";
-            case Phase1 -> "1";
-            case Phase3 -> "3";
-            case Phase4 -> "4";
-            case Phase5 -> "5";
-            case Phase6 -> "6";
-            case Quality -> "Quality";
-        };
+        return phase.stringName;
     }
 
     /**
@@ -59,16 +37,8 @@ public class PhaseUtils {
      * @return the phase as an enum
      */
     public static Phase getPhaseByString(String str) {
-        return switch (str) {
-            case "0" -> Phase.Phase0;
-            case "1" -> Phase.Phase1;
-            case "3" -> Phase.Phase3;
-            case "4" -> Phase.Phase4;
-            case "5" -> Phase.Phase5;
-            case "6" -> Phase.Phase6;
-            case "42" -> Phase.Quality;
-            default -> null;
-        };
+        if (str.equals(Phase.Quality.stringName)) return Phase.Quality;
+        return Phase.valueOf("Phase" + str);
     }
 
     /**
@@ -78,93 +48,60 @@ public class PhaseUtils {
      * @return its assignment number in Canvas
      */
     public static int getPhaseAssignmentNumber(Phase phase) {
-        return switch (phase) {
-            case Phase0 -> PHASE0_ASSIGNMENT_NUMBER;
-            case Phase1 -> PHASE1_ASSIGNMENT_NUMBER;
-            case Phase3 -> PHASE3_ASSIGNMENT_NUMBER;
-            case Phase4 -> PHASE4_ASSIGNMENT_NUMBER;
-            case Phase5 -> PHASE5_ASSIGNMENT_NUMBER;
-            case Phase6 -> PHASE6_ASSIGNMENT_NUMBER;
-            case Quality -> 0;
-        };
+        return phase.assignmentNumber;
     }
 
     public static Set<String> passoffPackagesToTest(Phase phase) throws GradingException {
-        return switch (phase) {
-            case Phase0 -> Set.of("passoffTests.chessTests", "passoffTests.chessTests.chessPieceTests");
-            case Phase1 -> Set.of("passoffTests.chessTests", "passoffTests.chessTests.chessExtraCredit");
-            case Phase3, Phase4 -> Set.of("passoffTests.serverTests");
-            case Phase5, Quality -> throw new GradingException("No passoff tests for this phase");
-            case Phase6 -> throw new GradingException("Not implemented");
-        };
+        var val = phase.passoffPackagesToTest;
+        if (val == null) {
+            throw new GradingException("No passoff tests for this phase");
+        }
+        return val;
     }
 
     public static Set<String> unitTestPackagesToTest(Phase phase) throws GradingException {
-        return switch (phase) {
-            case Phase0, Phase1, Phase6, Quality -> throw new GradingException("No unit tests for this phase");
-            case Phase3 -> Set.of("serviceTests");
-            case Phase4 -> Set.of("dataAccessTests");
-            case Phase5 -> Set.of("clientTests");
-        };
+        var val = phase.unitTestPackagesToTest;
+        if (val == null) {
+            throw new GradingException("No unit tests for this phase");
+        }
+        return val;
     }
 
     public static String unitTestCodeUnderTest(Phase phase) throws GradingException {
-        return switch (phase) {
-            case Phase0, Phase1, Phase6, Quality -> throw new GradingException("No unit tests for this phase");
-            case Phase3 -> "service";
-            case Phase4 -> "dao";
-            case Phase5 -> "server facade";
-        };
+        var val = phase.unitTestCodeUnderTest;
+        if (val == null) {
+            throw new GradingException("No unit tests for this phase");
+        }
+        return val;
     }
 
     public static int minUnitTests(Phase phase) throws GradingException {
-        return switch (phase) {
-            case Phase0, Phase1, Phase6, Quality -> throw new GradingException("No unit tests for this phase");
-            case Phase3 -> 13;
-            case Phase4 -> 18;
-            case Phase5 -> 12;
-        };
+        var val = phase.minUnitTests;
+        if (val < 0) {
+            throw new GradingException("No unit tests for this phase");
+        }
+        return val;
     }
 
+    @NonNull
     public static String getCanvasRubricId(Rubric.RubricType type, Phase phase) throws GradingException {
-        return switch (phase) {
-            case Phase0, Phase1 -> switch (type) {
-                case PASSOFF_TESTS -> "_1958";
-                case UNIT_TESTS, QUALITY -> throw new GradingException(String.format("No %s item for this phase", type));
-            };
-            case Phase3 -> switch (type) {
-                case PASSOFF_TESTS -> "_5202";
-                case UNIT_TESTS -> "90344_776";
-                case QUALITY -> "_3003";
-            };
-            case Phase4 -> switch (type) {
-                case PASSOFF_TESTS -> "_2614";
-                case UNIT_TESTS -> "_930";
-                case QUALITY -> throw new GradingException(String.format("No %s item for this phase", type));
-            };
-            case Phase5 -> switch (type) {
-                case UNIT_TESTS -> "_8849";
-                case PASSOFF_TESTS, QUALITY -> throw new GradingException(String.format("No %s item for this phase", type));
-            };
-            case Phase6 -> throw new GradingException("Phase 6 not implemented yet");
-            case Quality -> throw new GradingException("Not graded");
-        };
+        var rubricIds = phase.rubricIds;
+        if (rubricIds == null) {
+            throw new GradingException("Phase is not graded in Canvas");
+        }
+
+        var val = rubricIds.get(type);
+        if (val == null) {
+            throw new GradingException(String.format("No %s item for this phase", type));
+        }
+        return val;
     }
 
     public static String getModuleUnderTest(Phase phase) {
-        //FIXME : Not sure what's wrong with this but there was a empty fixme comment when I refactored -Michael
-        return switch (phase) {
-            case Phase0, Phase1 -> "shared";
-            case Phase3, Phase4, Phase6 -> "server";
-            case Phase5 -> "client";
-            case Quality -> null;
-        };
+        return phase.moduleUnderTest;
     }
 
     public static boolean isPhaseGraded(Phase phase) {
-        return switch (phase) {
-            case Phase0, Phase1, Phase3, Phase4, Phase5, Phase6 -> true;
-            case Quality -> false;
-        };
+        return phase.isGraded;
     }
 }

--- a/src/main/java/edu/byu/cs/util/PhaseUtils.java
+++ b/src/main/java/edu/byu/cs/util/PhaseUtils.java
@@ -89,22 +89,6 @@ public class PhaseUtils {
         };
     }
 
-    /**
-     * Returns the number of points the given phase is worth
-     *
-     * @param phase the phase in question
-     * @return the total points in Canvas as a float
-     */
-    public static float getTotalPoints(Phase phase) {
-        // FIXME
-        return switch (phase) {
-            case Phase0, Phase1, Phase4, Phase5 -> 125.0F;
-            case Phase3 -> 180.0F;
-            case Phase6 -> 155.0F;
-            case Quality -> 0.0F;
-        };
-    }
-
     public static Set<String> passoffPackagesToTest(Phase phase) throws GradingException {
         return switch (phase) {
             case Phase0 -> Set.of("passoffTests.chessTests", "passoffTests.chessTests.chessPieceTests");


### PR DESCRIPTION
## What is going on here?
Reorganizes the phase configuration data to leverage Java's object oriented model. Instead of using switch statements to provide information outside of the `Phase` object, that data is now being stored _in_ the `Phase` object.

So far, the existing getters are simply being changed internally to read the data differently. By the time this PR is finished, the entire `PhaseUtils` class will be ripped out and the code will be calling methods on the `Phase` object instead.

## Why go through the effort?
This shift, when complete, will make simplify the lives of future maintainers by having all related fields in one place which reduces the likelihood of a future developer forgetting to change some values.

Additionally, when stored as objects, it becomes a lot easier to make a leap and just store all of the data in a table instead of hardcoding configuration values in the source code files. Once the data is in a table, it also opens the door for settings pages and pretty GUI's to interact with the values and enable professors and more kinds of authorized people access to these controls.

Therefore, I see this as the first step in a longer process to have a robust, dynamic system on our hands that will outlive all of us as TA's.

## Todo List
- [ ] Move value getting methods directly into `Phase`
- [ ] Convert `Phase` into an `enum` which will enable dynamically loading
- [ ] Update all usages of `PhaseUtils` to use methods of `Phase`
- [ ] Make fields `private` instead of `public` after the methods exist for reading them
- [ ] Write JavaDoc documentation for each of the fields describing their purpose and nuances
- [ ] Eliminate `PhaseUtils`
- [ ] Eliminate nearly identical fields `Phase.stringValue` and `Phase.stringName`. They both exist because of a funky configuration in the `Quality` phase (it has `stringValue: "Quality"`, and `stringValue: "42"`). If we can reconcile to make them the same, then the rest of the duplication wouldn't be necessary. I didn't understand enough about why that separation existed in order to adjust it myself.
- [ ] Create a separate issue for storing and decoding all the data dynamically from a table (see #156).