### PR TITLE
Use secure random key for JWT signing

### DIFF
--- a/src/main/java/edu/byu/cs/util/JwtUtils.java
+++ b/src/main/java/edu/byu/cs/util/JwtUtils.java
@@ -1,20 +1,19 @@
 package edu.byu.cs.util;
 
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
 public class JwtUtils {
-
-    // FIXME: move key to external config
-    private static final String SECRET_KEY = "this_will_be_replaced_with_something_that_is_a_better_secret";
-    private static final SecretKey key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+    private static final SecretKey key = generateSecretKey();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JwtUtils.class);
 
@@ -44,5 +43,16 @@ public class JwtUtils {
             LOGGER.error("Error validating JWT", e);
             return null;
         }
+    }
+
+    private static SecretKey generateSecretKey() {
+        KeyGenerator keyGenerator;
+        try {
+            keyGenerator = KeyGenerator.getInstance("HmacSHA512");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("Unable to setup key JWT key generator", e);
+        }
+        keyGenerator.init(512, new SecureRandom());
+        return keyGenerator.generateKey();
     }
 }


### PR DESCRIPTION
# What this does
Currently the secret key for signing tokens is `this_will_be_replaced_with_something_that_is_a_better_secret`; not super ideal.

This PR changes the initial secret key generation to be secure. The downside is that the current frontend doesn't play nicely with this change if the server is restarted while somebody has an unexpired JWT stored.

Instead of fixing our current frontend to handle this, I think this should be a part of @DallinFromEarth's new frontend. Making this work shouldn't be too complicated, it would just require immediately expiring the JWT on the frontend when it becomes invalid. It could be a little tricky to tell the difference between good ol' `unauthorized` and `expired`, so further revisions might need to be made in this PR to accommodate that.

Comments are welcome