### PR TITLE
use updated docker-login action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,7 +30,7 @@ jobs:
       
       - 
         name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
Addresses this warning:

<img width="1218" alt="Screenshot 2024-04-13 at 2 33 52 PM" src="https://github.com/softwareconstruction240/autograder/assets/10139415/eee94fea-8253-4ae4-91f4-e3c83b5e4e2c">
