### PR TITLE
318 Use Grafana Loki for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ to preserve the learned knowledge for future generations.
     - Edit the "Server" run configuration
         - Paste in the single line of parameters to the line titled "Program arguments"
     - Save & apply the changes
-6. [Enable logging](#enabling-logging) by following the instructions below
-7. **Run the Autograder Locally**
+6. **Run the Autograder Locally**
     - Run your "Server" run configuration
     - Run the frontend by referencing the [section below](#running-locally)
    ```bash
@@ -169,15 +168,6 @@ To generate a Canvas API key:
 5. Provide the requested information in the modal box
 6. Copy the generated access token
 7. Use it as the value of the `--canvas-token` program argument above
-
-#### Enabling Logging
-
-To enable logging, add arguments `-Dlog4j2.configurationFile=log4j.properties -Dlog4j2.debug=false` as vm options.
-
-In IntelliJ, Go into the run configuration you want to use -> `Modify Options` -> `Add VM options`. This will reveal an
-additional box inside the edit menu. Paste the arguments into the box.
-
-If running from the command line, add the arguments immediately after the `java` command.
 
 #### Running Locally
 

--- a/loki-compose.yml
+++ b/loki-compose.yml
@@ -1,0 +1,43 @@
+version: "3"
+
+networks:
+  loki:
+
+services:
+  loki:
+    image: grafana/loki:2.9.0
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - loki
+
+  grafana:
+    environment:
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Loki
+          type: loki
+          access: proxy
+          orgId: 1
+          url: http://loki:3100
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        EOF
+        /run.sh
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    networks:
+      - loki

--- a/pom.xml
+++ b/pom.xml
@@ -74,33 +74,8 @@
             <version>5.10.2</version>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.23.1</version>
-        </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.23.1</version>
-        </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-slf4j2-impl -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j2-impl</artifactId>
-            <version>2.23.1</version>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>2.0.12</version>
-        </dependency>
 
         <!-- https://mvnrepository.com/artifact/commons-cli/commons-cli -->
         <dependency>
@@ -115,6 +90,27 @@
             <artifactId>mockito-core</artifactId>
             <version>5.11.0</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.5.5</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.loki4j</groupId>
+            <artifactId>loki-logback-appender</artifactId>
+            <version>1.5.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.13</version>
         </dependency>
 
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+
+<configuration>
+    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder" />
+    <import class="ch.qos.logback.core.ConsoleAppender" />
+    <import class="ch.qos.logback.core.rolling.RollingFileAppender" />
+    <import class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy" />
+    <import class="ch.qos.logback.classic.filter.ThresholdFilter" />
+
+    <appender name="STDOUT" class="ConsoleAppender">
+        <encoder class="PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} -- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>WARN</level>
+        </filter>
+        <rollingPolicy class="TimeBasedRollingPolicy">
+            <fileNamePattern>logs/logFile.%d{yyyy-MM-dd-mm}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} -- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>http://localhost:3100/loki/api/v1/push</url>
+        </http>
+        <format>
+            <label>
+                <pattern>app=autograder</pattern>
+            </label>
+            <message class="com.github.loki4j.logback.JsonLayout">
+                <threadName>
+                    <enabled>false</enabled>
+                </threadName>
+                <loggerName>
+                    <fieldName>class</fieldName>
+                </loggerName>
+            </message>
+        </format>
+        <batchMaxItems>
+            10
+        </batchMaxItems>
+        <batchTimeoutMs>
+            10000
+        </batchTimeoutMs>
+    </appender>
+
+    <logger name="edu.byu.cs" level="INFO">
+        <appender-ref ref="LOKI" />
+        <appender-ref ref="FILE" />
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
# This is the one you've all been waiting for
This PR swaps out `log4j` with `logback`, a more modern logging implementation.

## Logging channels
### `stdout`
Console logging to `stdout` at `INFO` level

### autograder.*.log
Rolling logs at `WARN` level, rolls at midnight each day

### [Grafana Loki](https://grafana.com/oss/loki/)
This is the cool one. Loki receives and stores `INFO` levels and displays them using Grafana, which for now will be hosted at `https://cs240.click/loki`

## Settings up for local development
To run Loki locally, you can use the new `loki-compose.yml` file with Docker Compose:
`docker compose -f loki-compose.yml up -d` and access it at http://localhost:3000

This PR removes the need for modifying VM options.
