### PR TITLE
filter with index before sorting

### DIFF
--- a/src/main/java/edu/byu/cs/dataAccess/sql/SubmissionSqlDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/sql/SubmissionSqlDao.java
@@ -9,14 +9,11 @@ import edu.byu.cs.dataAccess.SubmissionDao;
 import edu.byu.cs.model.Phase;
 import edu.byu.cs.model.Submission;
 
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.*;
-
-import static java.sql.Types.NULL;
 
 public class SubmissionSqlDao implements SubmissionDao {
     private static final ColumnDefinition[] COLUMN_DEFINITIONS = {
@@ -32,6 +29,7 @@ public class SubmissionSqlDao implements SubmissionDao {
             new ColumnDefinition<Submission>("rubric", s -> new Gson().toJson(s.rubric())),
             new ColumnDefinition<Submission>("admin", Submission::admin)
     };
+
     private static Submission readSubmission(ResultSet rs) throws SQLException {
         String netId = rs.getString("net_id");
         String repoUrl = rs.getString("repo_url");
@@ -55,6 +53,7 @@ public class SubmissionSqlDao implements SubmissionDao {
     public void insertSubmission(Submission submission) throws DataAccessException {
         sqlReader.insertItem(submission);
     }
+
     @Override
     public Collection<Submission> getSubmissionsForPhase(String netId, Phase phase) throws DataAccessException {
         return sqlReader.executeQuery(
@@ -80,30 +79,43 @@ public class SubmissionSqlDao implements SubmissionDao {
 
     @Override
     public Collection<Submission> getAllLatestSubmissions(int batchSize) throws DataAccessException {
-        return sqlReader.executeQuery(
-                """
-                    WHERE timestamp IN (
-                        SELECT MAX(timestamp)
-                        FROM %s
-                        GROUP BY net_id, phase
-                    )
-                    ORDER BY timestamp DESC
-                    """.formatted(sqlReader.getTableName()) +
-                (batchSize >= 0 ? "LIMIT ?" : ""),
-                ps -> {
-                    if (batchSize >= 0) {
-                        ps.setInt(1, batchSize);
-                    }
-                });
+        try (var connection = SqlDb.getConnection()) {
+            var statement = connection.prepareStatement(
+                    """
+                            SELECT s.net_id, s.repo_url, s.timestamp, s.phase, s.passed, s.score, s.num_commits, s.head_hash, s.notes, s.rubric, s.admin
+                            FROM submission s
+                            INNER JOIN (
+                                SELECT net_id, phase, MAX(timestamp) AS max_timestamp
+                                FROM submission
+                                GROUP BY net_id, phase
+                            ) s2 ON s.net_id = s2.net_id AND s.phase = s2.phase AND s.timestamp = s2.max_timestamp
+                            ORDER BY s2.max_timestamp DESC
+                            """ +
+                            (batchSize >= 0 ? "LIMIT ?" : "")
+            );
+            if (batchSize >= 0) {
+                statement.setInt(1, batchSize);
+            }
+            try (var results = statement.executeQuery()) {
+                List<Submission> submissions = new ArrayList<>();
+                while (results.next()) {
+                    Submission submission = readSubmission(results);
+                    submissions.add(submission);
+                }
+                return submissions;
+            }
+        } catch (SQLException e) {
+            throw new DataAccessException("Error getting latest submissions", e);
+        }
     }
 
     @Override
     public void removeSubmissionsByNetId(String netId) throws DataAccessException {
         sqlReader.executeUpdate(
                 """
-                    DELETE FROM %s
-                    WHERE net_id = ?
-                    """.formatted(sqlReader.getTableName()),
+                        DELETE FROM %s
+                        WHERE net_id = ?
+                        """.formatted(sqlReader.getTableName()),
                 ps -> ps.setString(1, netId)
         );
     }
@@ -128,10 +140,10 @@ public class SubmissionSqlDao implements SubmissionDao {
     public float getBestScoreForPhase(String netId, Phase phase) throws DataAccessException {
         return sqlReader.executeQuery(
                 """
-                    SELECT max(score) as highestScore
-                    FROM %s
-                    WHERE net_id = ? AND phase = ?
-                    """.formatted(sqlReader.getTableName()),
+                        SELECT max(score) as highestScore
+                        FROM %s
+                        WHERE net_id = ? AND phase = ?
+                        """.formatted(sqlReader.getTableName()),
                 ps -> {
                     ps.setString(1, netId);
                     ps.setString(2, phase.toString());


### PR DESCRIPTION
# What this does
This PR revises the query that fetches the latest submission for each student-phase. Arguably we don't need this feature anymore, but given that it is still present I wanted to patch our memory overflow error:

`ERROR 1038 (HY001): Out of sort memory, consider increasing server sort buffer size`

I tried <ins>a lot</ins> of different ways to get the query to fallback on indexes, but the conclusion of my research was that indexes are hard.

This PR modifies the query to filter out all the submissions we don't care about _before_ sorting. This technically doesn't fix the problem and mostly just moves the issue further down, but I'd be pretty surprised if we encounter it again, especially if intend on clearing the database each semester