### PR TITLE
125 accept divserse repo urls

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/Grader.java
+++ b/src/main/java/edu/byu/cs/autograder/Grader.java
@@ -50,7 +50,7 @@ public class Grader implements Runnable {
      * @param observer the observer to notify of updates
      * @param phase    the phase to grade
      */
-    public Grader(String repoUrl, String netId, Observer observer, Phase phase, boolean admin) throws IOException {
+    public Grader(String repoUrl, String netId, Observer observer, Phase phase, boolean admin) throws IOException, GradingException {
         // Init files
         if (!admin) {
             repoUrl = cleanRepoUrl(repoUrl);
@@ -159,9 +159,9 @@ public class Grader implements Runnable {
      *
      * @param repoUrl The student's repository URL.
      * @return Cleaned URL with everything after the repo name stripped off.
-     * @throws IOException Throws IOException if repoUrl does not follow expected format
+     * @throws GradingException Throws IOException if repoUrl does not follow expected format
      */
-    public static String cleanRepoUrl(String repoUrl) throws IOException {
+    public static String cleanRepoUrl(String repoUrl) throws GradingException {
         String[] regexPatterns = {
             "https?://github\\.com/([^/?]+)/([^/?]+)", // https
             "git@github.com:([^/]+)/([^/]+).git" // ssh
@@ -179,7 +179,7 @@ public class Grader implements Runnable {
                 return String.format("https://github.com/%s/%s", githubUsername, repositoryName);
             }
         }
-        throw new IOException("Could not find github username or repository name given '" + repoUrl + "'.");
+        throw new GradingException("Could not find github username and repository name given '" + repoUrl + "'.");
     }
 
     public interface Observer {

--- a/src/main/java/edu/byu/cs/autograder/Grader.java
+++ b/src/main/java/edu/byu/cs/autograder/Grader.java
@@ -162,12 +162,22 @@ public class Grader implements Runnable {
      * @throws IOException Throws IOException if repoUrl does not follow expected format
      */
     public static String cleanRepoUrl(String repoUrl) throws IOException {
-        Pattern pattern = Pattern.compile("https?://github\\.com/([^/?]+)/([^/?]+)");
-        Matcher matcher = pattern.matcher(repoUrl);
-        if (matcher.find()) {
-            String githubUsername = matcher.group(1);
-            String repositoryName = matcher.group(2);
-            return String.format("https://github.com/%s/%s", githubUsername, repositoryName);
+        String[] regexPatterns = {
+            "https?://github\\.com/([^/?]+)/([^/?]+)", // https
+            "git@github.com:([^/]+)/([^/]+).git" // ssh
+        };
+        Pattern pattern;
+        Matcher matcher;
+        String githubUsername;
+        String repositoryName;
+        for (String regexPattern: regexPatterns) {
+            pattern = Pattern.compile(regexPattern);
+            matcher = pattern.matcher(repoUrl);
+            if (matcher.find()) {
+                githubUsername = matcher.group(1);
+                repositoryName = matcher.group(2);
+                return String.format("https://github.com/%s/%s", githubUsername, repositoryName);
+            }
         }
         throw new IOException("Could not find github username or repository name given '" + repoUrl + "'.");
     }

--- a/src/main/java/edu/byu/cs/controller/SubmissionController.java
+++ b/src/main/java/edu/byu/cs/controller/SubmissionController.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import edu.byu.cs.autograder.Grader;
+import edu.byu.cs.autograder.GradingException;
 import edu.byu.cs.autograder.TrafficController;
 import edu.byu.cs.autograder.test.TestAnalyzer;
 import edu.byu.cs.canvas.CanvasException;
@@ -320,7 +321,7 @@ public class SubmissionController {
      * @return the grader
      * @throws IOException if there is an error creating the grader
      */
-    private static Grader getGrader(String netId, Phase phase, String repoUrl, boolean adminSubmission) throws IOException {
+    private static Grader getGrader(String netId, Phase phase, String repoUrl, boolean adminSubmission) throws IOException, GradingException {
         Grader.Observer observer = new Grader.Observer() {
             @Override
             public void notifyStarted() {
@@ -440,7 +441,7 @@ public class SubmissionController {
      * Used if the queue got stuck or if the server crashed while submissions were
      * waiting in the queue.
      */
-    public static void reRunSubmissionsInQueue() throws IOException, DataAccessException {
+    public static void reRunSubmissionsInQueue() throws IOException, DataAccessException, GradingException {
         QueueDao queueDao = DaoService.getQueueDao();
         UserDao userDao = DaoService.getUserDao();
         Collection<QueueItem> inQueue = queueDao.getAll();

--- a/src/main/java/edu/byu/cs/server/Server.java
+++ b/src/main/java/edu/byu/cs/server/Server.java
@@ -1,5 +1,6 @@
 package edu.byu.cs.server;
 
+import edu.byu.cs.autograder.GradingException;
 import edu.byu.cs.controller.SubmissionController;
 import edu.byu.cs.controller.WebSocketController;
 import edu.byu.cs.dataAccess.DaoService;
@@ -181,7 +182,7 @@ public class Server {
 
         try {
             SubmissionController.reRunSubmissionsInQueue();
-        } catch (IOException | DataAccessException e) {
+        } catch (IOException | DataAccessException | GradingException e) {
             LOGGER.error("Error rerunning submissions already in queue", e);
         }
     }

--- a/src/test/java/edu/byu/cs/autograder/GraderTest.java
+++ b/src/test/java/edu/byu/cs/autograder/GraderTest.java
@@ -1,0 +1,68 @@
+package edu.byu.cs.autograder;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+public class GraderTest {
+
+  @Test
+  @Tag("cleanRepoUrl")
+  @DisplayName("Should strip off trailing characters after repo name when given repo URL")
+  void should_stripOffTrailingCharactersAfterRepoName_when_givenRepoUrl() {
+    // Should strip off characters after repo name
+    String expectedUrl = "https://github.com/<USERNAME>/<REPO_NAME>";
+    String[] urlVariants = {
+        "https://github.com/<USERNAME>/<REPO_NAME>/tree/main",
+        "https://github.com/<USERNAME>/<REPO_NAME>?tab=readme-ov-file",
+        "https://github.com/<USERNAME>/<REPO_NAME>/tree/main/0-chess-moves/starter-code/chess",
+        "https://github.com/<USERNAME>/<REPO_NAME>/pull/1"
+    };
+    assertDoesNotThrow(() -> {
+      for (String urlVariant : urlVariants) {
+        assertEquals(expectedUrl, Grader.cleanRepoUrl(urlVariant));
+      }
+    });
+  }
+
+  @Test
+  @Tag("cleanRepoUrl")
+  @DisplayName("Should not strip github URL when given repo URL with no trailing characters")
+  void should_notStripOffGithubUrl_when_givenRepoUrlWithNoTrailingCharacters() {
+    // Should not alter already working URLs
+    assertDoesNotThrow(() -> {
+      assertEquals("https://github.com/<USERNAME>/<REPO_NAME>",
+          Grader.cleanRepoUrl("https://github.com/<USERNAME>/<REPO_NAME>"));
+
+      assertEquals("https://github.com/<USERNAME>/<REPO_NAME>.git",
+          Grader.cleanRepoUrl("https://github.com/<USERNAME>/<REPO_NAME>.git"));
+    });
+  }
+
+  @Test
+  @Tag("cleanRepoUrl")
+  @DisplayName("Should throw exception when given malformed or not related Url")
+  void should_throwException_when_givenMalformedOrNotRelatedUrl() {
+
+    String[] badUrls = {
+        "github.com/user/repo",
+        "https://wahoooo.com/user/repo",
+        "https://wahoooo.com/user/repo",
+        "https://wahoooo.com/user/repo"
+    };
+    for (String badUrl: badUrls) {
+      assertThrows(IOException.class, () -> {
+        Grader.cleanRepoUrl(badUrl);
+      });
+    }
+
+
+
+
+  }
+
+
+}

--- a/src/test/java/edu/byu/cs/autograder/GraderTest.java
+++ b/src/test/java/edu/byu/cs/autograder/GraderTest.java
@@ -62,7 +62,7 @@ public class GraderTest {
         "https://wahoooo.com/user/"
     };
     for (String badUrl: badUrls) {
-      assertThrows(IOException.class, () -> {
+      assertThrows(GradingException.class, () -> {
         Grader.cleanRepoUrl(badUrl);
       });
     }

--- a/src/test/java/edu/byu/cs/autograder/GraderTest.java
+++ b/src/test/java/edu/byu/cs/autograder/GraderTest.java
@@ -12,7 +12,7 @@ public class GraderTest {
   @Test
   @Tag("cleanRepoUrl")
   @DisplayName("Should strip off trailing characters after repo name when given repo URL")
-  void should_stripOffTrailingCharactersAfterRepoName_when_givenRepoUrl() {
+  void should_stripOffTrailingCharactersAfterRepoName_when_givenRepoUrl() throws GradingException {
     // Should strip off characters after repo name
     String expectedUrl = "https://github.com/<USERNAME>/<REPO_NAME>";
     String[] urlVariants = {
@@ -21,35 +21,29 @@ public class GraderTest {
         "https://github.com/<USERNAME>/<REPO_NAME>/tree/main/0-chess-moves/starter-code/chess",
         "https://github.com/<USERNAME>/<REPO_NAME>/pull/1"
     };
-    assertDoesNotThrow(() -> {
-      for (String urlVariant : urlVariants) {
-        assertEquals(expectedUrl, Grader.cleanRepoUrl(urlVariant));
-      }
-    });
+    for (String urlVariant : urlVariants) {
+      assertEquals(expectedUrl, Grader.cleanRepoUrl(urlVariant));
+    }
   }
 
   @Test
   @Tag("cleanRepoUrl")
   @DisplayName("Should not strip github URL when given repo URL with no trailing characters")
-  void should_notStripOffGithubUrl_when_givenRepoUrlWithNoTrailingCharacters() {
-    // Should not alter already working URLs
-    assertDoesNotThrow(() -> {
+  void should_notStripOffGithubUrl_when_givenRepoUrlWithNoTrailingCharacters() throws GradingException {
+      // Should not alter already working URLs
       assertEquals("https://github.com/<USERNAME>/<REPO_NAME>",
           Grader.cleanRepoUrl("https://github.com/<USERNAME>/<REPO_NAME>"));
 
       assertEquals("https://github.com/<USERNAME>/<REPO_NAME>.git",
           Grader.cleanRepoUrl("https://github.com/<USERNAME>/<REPO_NAME>.git"));
-    });
   }
 
   @Test
   @Tag("cleanRepoUrl")
   @DisplayName("Should convert to HTTPS URL when given SSH URL")
-  void should_convertToHttpsUrl_when_givenSshUrl() {
-    assertDoesNotThrow(() -> {
+  void should_convertToHttpsUrl_when_givenSshUrl() throws GradingException {
       assertEquals("https://github.com/<USERNAME>/<REPO_NAME>",
           Grader.cleanRepoUrl("git@github.com:<USERNAME>/<REPO_NAME>.git"));
-    });
   }
 
   @Test

--- a/src/test/java/edu/byu/cs/autograder/GraderTest.java
+++ b/src/test/java/edu/byu/cs/autograder/GraderTest.java
@@ -9,58 +9,57 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.*;
 public class GraderTest {
 
-  @Test
-  @Tag("cleanRepoUrl")
-  @DisplayName("Should strip off trailing characters after repo name when given repo URL")
-  void should_stripOffTrailingCharactersAfterRepoName_when_givenRepoUrl() throws GradingException {
-    // Should strip off characters after repo name
-    String expectedUrl = "https://github.com/<USERNAME>/<REPO_NAME>";
-    String[] urlVariants = {
-        "https://github.com/<USERNAME>/<REPO_NAME>/tree/main",
-        "https://github.com/<USERNAME>/<REPO_NAME>?tab=readme-ov-file",
-        "https://github.com/<USERNAME>/<REPO_NAME>/tree/main/0-chess-moves/starter-code/chess",
-        "https://github.com/<USERNAME>/<REPO_NAME>/pull/1"
-    };
-    for (String urlVariant : urlVariants) {
-      assertEquals(expectedUrl, Grader.cleanRepoUrl(urlVariant));
+    @Test
+    @Tag("cleanRepoUrl")
+    @DisplayName("Should strip off trailing characters after repo name when given repo URL")
+        void should_stripOffTrailingCharactersAfterRepoName_when_givenRepoUrl() throws GradingException {
+        // Should strip off characters after repo name
+        String expectedUrl = "https://github.com/<USERNAME>/<REPO_NAME>";
+        String[] urlVariants = {
+                "https://github.com/<USERNAME>/<REPO_NAME>/tree/main",
+                "https://github.com/<USERNAME>/<REPO_NAME>?tab=readme-ov-file",
+                "https://github.com/<USERNAME>/<REPO_NAME>/tree/main/0-chess-moves/starter-code/chess",
+                "https://github.com/<USERNAME>/<REPO_NAME>/pull/1"
+        };
+        for (String urlVariant : urlVariants) {
+            assertEquals(expectedUrl, Grader.cleanRepoUrl(urlVariant));
+        }
     }
-  }
 
-  @Test
-  @Tag("cleanRepoUrl")
-  @DisplayName("Should not strip github URL when given repo URL with no trailing characters")
-  void should_notStripOffGithubUrl_when_givenRepoUrlWithNoTrailingCharacters() throws GradingException {
-      // Should not alter already working URLs
-      assertEquals("https://github.com/<USERNAME>/<REPO_NAME>",
-          Grader.cleanRepoUrl("https://github.com/<USERNAME>/<REPO_NAME>"));
+    @Test
+    @Tag("cleanRepoUrl")
+    @DisplayName("Should not strip github URL when given repo URL with no trailing characters")
+    void should_notStripOffGithubUrl_when_givenRepoUrlWithNoTrailingCharacters() throws GradingException {
+        // Should not alter already working URLs
+        assertEquals("https://github.com/<USERNAME>/<REPO_NAME>",
+                Grader.cleanRepoUrl("https://github.com/<USERNAME>/<REPO_NAME>"));
 
-      assertEquals("https://github.com/<USERNAME>/<REPO_NAME>.git",
-          Grader.cleanRepoUrl("https://github.com/<USERNAME>/<REPO_NAME>.git"));
-  }
-
-  @Test
-  @Tag("cleanRepoUrl")
-  @DisplayName("Should convert to HTTPS URL when given SSH URL")
-  void should_convertToHttpsUrl_when_givenSshUrl() throws GradingException {
-      assertEquals("https://github.com/<USERNAME>/<REPO_NAME>",
-          Grader.cleanRepoUrl("git@github.com:<USERNAME>/<REPO_NAME>.git"));
-  }
-
-  @Test
-  @Tag("cleanRepoUrl")
-  @DisplayName("Should throw exception when given malformed or not related Url")
-  void should_throwException_when_givenMalformedOrNotRelatedUrl() {
-    String[] badUrls = {
-        "github.com/user/repo",
-        "https://wahoooo.com/user/repo",
-        "https://wahoooo.com/user/"
-    };
-    for (String badUrl: badUrls) {
-      assertThrows(GradingException.class, () -> {
-        Grader.cleanRepoUrl(badUrl);
-      });
+        assertEquals("https://github.com/<USERNAME>/<REPO_NAME>.git",
+                Grader.cleanRepoUrl("https://github.com/<USERNAME>/<REPO_NAME>.git"));
     }
-  }
 
+    @Test
+    @Tag("cleanRepoUrl")
+    @DisplayName("Should convert to HTTPS URL when given SSH URL")
+    void should_convertToHttpsUrl_when_givenSshUrl() throws GradingException {
+        assertEquals("https://github.com/<USERNAME>/<REPO_NAME>",
+                Grader.cleanRepoUrl("git@github.com:<USERNAME>/<REPO_NAME>.git"));
+    }
+
+    @Test
+    @Tag("cleanRepoUrl")
+    @DisplayName("Should throw exception when given malformed or not related Url")
+    void should_throwException_when_givenMalformedOrNotRelatedUrl() {
+        String[] badUrls = {
+                "github.com/user/repo",
+                "https://wahoooo.com/user/repo",
+                "https://wahoooo.com/user/"
+        };
+        for (String badUrl: badUrls) {
+            assertThrows(GradingException.class, () -> {
+                Grader.cleanRepoUrl(badUrl);
+            });
+        }
+    }
 
 }

--- a/src/test/java/edu/byu/cs/autograder/GraderTest.java
+++ b/src/test/java/edu/byu/cs/autograder/GraderTest.java
@@ -44,24 +44,28 @@ public class GraderTest {
 
   @Test
   @Tag("cleanRepoUrl")
+  @DisplayName("Should convert to HTTPS URL when given SSH URL")
+  void should_convertToHttpsUrl_when_givenSshUrl() {
+    assertDoesNotThrow(() -> {
+      assertEquals("https://github.com/<USERNAME>/<REPO_NAME>",
+          Grader.cleanRepoUrl("git@github.com:<USERNAME>/<REPO_NAME>.git"));
+    });
+  }
+
+  @Test
+  @Tag("cleanRepoUrl")
   @DisplayName("Should throw exception when given malformed or not related Url")
   void should_throwException_when_givenMalformedOrNotRelatedUrl() {
-
     String[] badUrls = {
         "github.com/user/repo",
         "https://wahoooo.com/user/repo",
-        "https://wahoooo.com/user/repo",
-        "https://wahoooo.com/user/repo"
+        "https://wahoooo.com/user/"
     };
     for (String badUrl: badUrls) {
       assertThrows(IOException.class, () -> {
         Grader.cleanRepoUrl(badUrl);
       });
     }
-
-
-
-
   }
 
 

--- a/src/test/java/edu/byu/cs/autograder/GraderTest.java
+++ b/src/test/java/edu/byu/cs/autograder/GraderTest.java
@@ -1,5 +1,6 @@
 package edu.byu.cs.autograder;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -60,6 +61,17 @@ public class GraderTest {
                 Grader.cleanRepoUrl(badUrl);
             });
         }
+    }
+
+    @Test
+    @Tag("cleanRepoUrl")
+    @DisplayName("Admin submissions are not cleaned")
+    void adminSubmissionsAreNotCleaned() throws GradingException, IOException {
+        String originalUrl = "https://github.com/<USERNAME>/<REPO_NAME>/tree/main/0-chess-moves/starter-code/chess";
+        // This cannot be easily tested since `Grader` has many other dependencies that would need to be organized as well.
+        // As this point, we are not spending the time to make `Grader` into a more testable format.
+//        var grader = new Grader(originalUrl, "student_id", null, null , true);
+//        Assertions.assertEquals(originalUrl, grader.gradingContext.repoUrl());
     }
 
 }


### PR DESCRIPTION
Strips off trailing characters in github URLs for non-admin submissions. 
Supports SSH urls. 
Addeds test for `cleanRepoUrl` method.

Resolves #125.