### PR TITLE
Disable admin commit verification

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -44,8 +44,8 @@ public class GitHelper {
         File stageRepo = gradingContext.stageRepo();
         fetchRepo(stageRepo);
 
-        boolean gradedPhase = PhaseUtils.isPhaseGraded(gradingContext.phase());
-        return (gradedPhase  && !gradingContext.admin()) ?
+        boolean requiresVerification = PhaseUtils.isPhaseGraded(gradingContext.phase()) && !gradingContext.admin();
+        return requiresVerification ?
                 verifyCommitRequirements(stageRepo) : skipCommitVerification(stageRepo);
     }
 

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -45,7 +45,8 @@ public class GitHelper {
         fetchRepo(stageRepo);
 
         boolean gradedPhase = PhaseUtils.isPhaseGraded(gradingContext.phase());
-        return gradedPhase ? verifyCommitRequirements(stageRepo) : skipCommitVerification(stageRepo);
+        return (gradedPhase  && !gradingContext.admin()) ?
+                verifyCommitRequirements(stageRepo) : skipCommitVerification(stageRepo);
     }
 
     /**

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -143,7 +143,7 @@ public class GitHelper {
 
         CommitsByDay commitHistory = CommitAnalytics.countCommitsByDay(git, lowerThreshold, upperThreshold);
         CommitVerificationResult commitVerificationResult = commitsPassRequirements(commitHistory);
-        LOGGER.debug("Commit verification result: " + JSON.toString(commitVerificationResult));
+        LOGGER.debug("Commit verification result: {}", JSON.toString(commitVerificationResult));
 
         var observer = gradingContext.observer();
         if (commitVerificationResult.verified()) {


### PR DESCRIPTION
Previously, the git verification ran for admins, but just was never reported when scoring. However, the commit verification could throw exceptions if the admin had submitted with a different repository in the past. This completely disables the verification for admins so the exception isn't thrown.