### PR TITLE
Fix previous test grader

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/test/PassoffTestGrader.java
+++ b/src/main/java/edu/byu/cs/autograder/test/PassoffTestGrader.java
@@ -2,7 +2,6 @@ package edu.byu.cs.autograder.test;
 
 import edu.byu.cs.autograder.GradingContext;
 import edu.byu.cs.autograder.GradingException;
-import edu.byu.cs.model.Phase;
 import edu.byu.cs.model.RubricConfig;
 import edu.byu.cs.util.PhaseUtils;
 
@@ -11,24 +10,8 @@ import java.util.*;
 
 public class PassoffTestGrader extends TestGrader {
 
-    /**
-     * The names of the test files with extra credit tests (excluding .java)
-     */
-    protected final Set<String> extraCreditTests = new HashSet<>();
-
-    /**
-     * The value (in percentage) of each extra credit category
-     */
-    protected float extraCreditValue = 0;
-
-
     public PassoffTestGrader(GradingContext gradingContext) {
         super(gradingContext);
-        if (gradingContext.phase() == Phase.Phase1) {
-            extraCreditTests.add("CastlingTests");
-            extraCreditTests.add("EnPassantTests");
-            extraCreditValue = .04f;
-        }
     }
 
     @Override
@@ -48,7 +31,7 @@ public class PassoffTestGrader extends TestGrader {
 
     @Override
     protected Set<String> extraCreditTests() {
-        return extraCreditTests;
+        return PhaseUtils.extraCreditTests(gradingContext.phase());
     }
 
     @Override
@@ -70,6 +53,7 @@ public class PassoffTestGrader extends TestGrader {
         // extra credit calculation
         if (score < 1f) return score;
         Map<String, Float> ecScores = getECScores(testResults);
+        float extraCreditValue = PhaseUtils.extraCreditValue(gradingContext.phase());
         for (String category : extraCreditTests()) {
             if (ecScores.get(category) == 1f) {
                 score += extraCreditValue;
@@ -90,6 +74,7 @@ public class PassoffTestGrader extends TestGrader {
         else notes.append("Some required tests failed");
 
         Map<String, Float> ecScores = getECScores(testResults);
+        float extraCreditValue = PhaseUtils.extraCreditValue(gradingContext.phase());
         float totalECPoints = ecScores.values().stream().reduce(0f, Float::sum) * extraCreditValue;
 
         if (totalECPoints > 0f) notes.append("\nExtra credit tests: +").append(totalECPoints * 100).append("%");

--- a/src/main/java/edu/byu/cs/autograder/test/PreviousPhasePassoffTestGrader.java
+++ b/src/main/java/edu/byu/cs/autograder/test/PreviousPhasePassoffTestGrader.java
@@ -14,6 +14,9 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class PreviousPhasePassoffTestGrader extends TestGrader{
+    private static final String ERROR_MESSAGE =
+            "Failed previous tests. Cannot pass off until previous tests (excluding extra credit tests) pass";
+
     public PreviousPhasePassoffTestGrader(GradingContext gradingContext) {
         super(gradingContext);
     }
@@ -67,17 +70,13 @@ public class PreviousPhasePassoffTestGrader extends TestGrader{
     @Override
     protected float getScore(TestAnalyzer.TestAnalysis testResults) throws GradingException {
         if (testResults.root().getNumTestsFailed() == 0) return 1f;
-        throw new GradingException("Failed previous tests. Cannot pass off until previous tests pass", testResults);
+        throw new GradingException(ERROR_MESSAGE, testResults);
     }
 
     @Override
     protected String getNotes(TestAnalyzer.TestAnalysis results) {
-        if (results.root().getNumTestsFailed() == 0) {
-            return "All previous tests passed";
-        }
-        else {
-            return "Failed previous tests. Cannot pass off until previous tests pass";
-        }
+        if (results.root().getNumTestsFailed() == 0) return "All previous tests passed";
+        else return ERROR_MESSAGE;
     }
 
     @Override

--- a/src/main/java/edu/byu/cs/autograder/test/PreviousPhasePassoffTestGrader.java
+++ b/src/main/java/edu/byu/cs/autograder/test/PreviousPhasePassoffTestGrader.java
@@ -14,8 +14,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class PreviousPhasePassoffTestGrader extends TestGrader{
-    private static final String ERROR_MESSAGE =
-            "Failed previous tests. Cannot pass off until previous tests (excluding extra credit tests) pass";
+    private static final String ERROR_MESSAGE = "Failed previous tests. Cannot pass off until previous tests pass";
 
     public PreviousPhasePassoffTestGrader(GradingContext gradingContext) {
         super(gradingContext);
@@ -70,7 +69,13 @@ public class PreviousPhasePassoffTestGrader extends TestGrader{
     @Override
     protected float getScore(TestAnalyzer.TestAnalysis testResults) throws GradingException {
         if (testResults.root().getNumTestsFailed() == 0) return 1f;
+        removeExtraCreditTests(testResults.root(), extraCreditTests());
         throw new GradingException(ERROR_MESSAGE, testResults);
+    }
+
+    private void removeExtraCreditTests(TestAnalyzer.TestNode node, Set<String> extraCreditTests) {
+        extraCreditTests.forEach((ecTest) -> node.getChildren().remove(ecTest));
+        node.getChildren().forEach((s, child) -> removeExtraCreditTests(child, extraCreditTests));
     }
 
     @Override

--- a/src/main/java/edu/byu/cs/autograder/test/PreviousPhasePassoffTestGrader.java
+++ b/src/main/java/edu/byu/cs/autograder/test/PreviousPhasePassoffTestGrader.java
@@ -33,6 +33,11 @@ public class PreviousPhasePassoffTestGrader extends TestGrader{
         return allPreviousPhases(PhaseUtils::passoffPackagesToTest);
     }
 
+    @Override
+    protected Set<String> extraCreditTests() throws GradingException {
+        return allPreviousPhases(PhaseUtils::extraCreditTests);
+    }
+
     private <T> Set<T> allPreviousPhases(PhaseFunction<T> func) throws GradingException {
         try {
             Set<T> set = new HashSet<>();
@@ -52,11 +57,6 @@ public class PreviousPhasePassoffTestGrader extends TestGrader{
     @FunctionalInterface
     private interface PhaseFunction<T> {
         Collection<T> apply(Phase phase) throws GradingException;
-    }
-
-    @Override
-    protected Set<String> extraCreditTests() {
-        return new HashSet<>();
     }
 
     @Override

--- a/src/main/java/edu/byu/cs/autograder/test/TestGrader.java
+++ b/src/main/java/edu/byu/cs/autograder/test/TestGrader.java
@@ -84,7 +84,7 @@ public abstract class TestGrader {
 
     protected abstract Set<String> packagesToTest() throws GradingException;
 
-    protected abstract Set<String> extraCreditTests();
+    protected abstract Set<String> extraCreditTests() throws GradingException;
 
     protected abstract String testName();
 

--- a/src/main/java/edu/byu/cs/util/PhaseUtils.java
+++ b/src/main/java/edu/byu/cs/util/PhaseUtils.java
@@ -4,6 +4,7 @@ import edu.byu.cs.autograder.GradingException;
 import edu.byu.cs.model.Phase;
 import edu.byu.cs.model.Rubric;
 
+import java.util.HashSet;
 import java.util.Set;
 
 public class PhaseUtils {
@@ -175,4 +176,15 @@ public class PhaseUtils {
             case Phase5, Phase6, Quality -> false;
         };
     }
+
+    public static Set<String> extraCreditTests(Phase phase) {
+        if(phase == Phase.Phase1) return Set.of("CastlingTests", "EnPassantTests");
+        return new HashSet<>();
+    }
+
+    public static float extraCreditValue(Phase phase) {
+        if(phase == Phase.Phase1) return .04f;
+        return 0;
+    }
+
 }


### PR DESCRIPTION
The Previous Phase Passoff Test Grader had a bug where extra credit tests were counted as previous tests, and students could not passoff subsequent phases if they didn't have the previous extra credit done. This fixes that.