### PR TITLE
Correct line counting issue

### DIFF
--- a/src/main/java/edu/byu/cs/analytics/CommitAnalytics.java
+++ b/src/main/java/edu/byu/cs/analytics/CommitAnalytics.java
@@ -189,7 +189,8 @@ public class CommitAnalytics {
         int totalChanges = 0;
         for (var diff : diffs) {
             FileHeader fileHeader = diffFormatter.toFileHeader(diff);
-            totalChanges += fileHeader.toEditList().stream().mapToInt(Edit::getLengthB).sum();
+            // https://archive.eclipse.org/jgit/docs/jgit-2.0.0.201206130900-r/apidocs/org/eclipse/jgit/diff/Edit.html
+            totalChanges += fileHeader.toEditList().stream().mapToInt(e -> e.getLengthA() + e.getLengthB()).sum();
         }
 
         return totalChanges;

--- a/src/main/java/edu/byu/cs/autograder/git/CommitVerificationResult.java
+++ b/src/main/java/edu/byu/cs/autograder/git/CommitVerificationResult.java
@@ -5,25 +5,26 @@ import org.eclipse.jgit.annotations.NonNull;
 import java.time.Instant;
 
 /**
- * An in-memory model that carries information
+ * An in-memory model that reports the decisions, a few key details,
+ * and some debug information from the Commit Verification System.
  *
  * @see edu.byu.cs.model.Submission.ScoreVerification#verifiedStatus() for more information about `penaltyPct`.
  *
- * @param verified
- * @param isCachedResponse
- * @param numCommits
- * @param numDays
+ * @param verified Officially reports the verified status of the submission.
+ * @param isCachedResponse Whether this was freshly generated, or passed through from a previous decision.
+ * @param significantCommits Total number of commits above the minimum line threshold.
+ * @param numDays The number of unique days with commits. Insignificant commits contribute to this number.
  * @param penaltyPct A reduction to the phase, if any, when a TA approved an unapproved score. [0-100]
- * @param failureMessage
- * @param minAllowedThreshold
- * @param maxAllowedThreshold
- * @param headHash
- * @param tailHash
+ * @param failureMessage A string that will be presented to the use when this the result is not verified.
+ * @param minAllowedThreshold Debug purposes. The min timestamp considered.
+ * @param maxAllowedThreshold Debug. The maximum timestamp considered.
+ * @param headHash Debug. The head hash evaluated. Not null.
+ * @param tailHash Debug. The tail hash evaluated. Sometimes null.
  */
 public record CommitVerificationResult(
         @NonNull boolean verified,
         boolean isCachedResponse,
-        int numCommits,
+        int significantCommits,
         int numDays,
         int penaltyPct,
         @NonNull String failureMessage,

--- a/src/main/java/edu/byu/cs/autograder/git/CommitVerificationResult.java
+++ b/src/main/java/edu/byu/cs/autograder/git/CommitVerificationResult.java
@@ -12,6 +12,7 @@ import java.time.Instant;
  *
  * @param verified Officially reports the verified status of the submission.
  * @param isCachedResponse Whether this was freshly generated, or passed through from a previous decision.
+ * @param totalCommits Total number of relevant commits analyzed. Excludes merges and commits before the tail threshold.
  * @param significantCommits Total number of commits above the minimum line threshold.
  * @param numDays The number of unique days with commits. Insignificant commits contribute to this number.
  * @param penaltyPct A reduction to the phase, if any, when a TA approved an unapproved score. [0-100]
@@ -24,6 +25,7 @@ import java.time.Instant;
 public record CommitVerificationResult(
         @NonNull boolean verified,
         boolean isCachedResponse,
+        int totalCommits,
         int significantCommits,
         int numDays,
         int penaltyPct,

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -76,7 +76,7 @@ public class GitHelper {
         String headHash = getHeadHash(stageRepo);
         return new CommitVerificationResult(
                 true, false,
-                0, 0, 0, null,
+                0, 0, 0, 0, null,
                 Instant.MIN, Instant.MAX,
                 headHash, null
         );
@@ -125,7 +125,7 @@ public class GitHelper {
                     "You still need to meet with a TA or a professor to gain credit for this phase.";
         return new CommitVerificationResult(
                 verified, true,
-                0, 0, scoreVerification.penaltyPct(), message,
+                0, 0, 0, scoreVerification.penaltyPct(), message,
                 null, null,
                 firstPassingSubmission.headHash(), null
         );
@@ -188,6 +188,7 @@ public class GitHelper {
         return new CommitVerificationResult(
                 errorMessages.isEmpty(),
                 false,
+                numCommits,
                 (int) significantCommits,
                 daysWithCommits,
                 0, // Penalties are applied by TA's upon approval of unapproved submissions

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -188,7 +188,7 @@ public class GitHelper {
         return new CommitVerificationResult(
                 errorMessages.isEmpty(),
                 false,
-                numCommits,
+                (int) significantCommits,
                 daysWithCommits,
                 0, // Penalties are applied by TA's upon approval of unapproved submissions
                 String.join("\n", errorMessages),

--- a/src/test/java/edu/byu/cs/autograder/score/ScorerTest.java
+++ b/src/test/java/edu/byu/cs/autograder/score/ScorerTest.java
@@ -278,7 +278,7 @@ class ScorerTest {
         String headHash = "<" + statusStr + "_COMMIT_VERIFICATION>";
 
         return new CommitVerificationResult(
-                verified, isCached, 0, 0, 0,
+                verified, isCached, 0, 0, 0, 0,
                 "", null, null,
                 headHash, null);
     }


### PR DESCRIPTION
The previous code counted only the insertions in each commit. Per the definition we agreed on, this changes it to count both insertions and deletions. This issue will undercount the changes and will affect grading by effectively setting the line change threshold higher.

Additionally, the internal methods were previously reporting the total commits encountered instead of only the substantial commits. This issue does not affect grading.

This does raise a question about definitions. Currently, commits with low change counts still count towards the unique days with commits, even though they do not count towards the substantial commit threshold. This seems fair as it allows a student to do a little setup work on one day, and then do the bulk of the work on a few days. The student still had commits on multiple days even if the substantial commits were all on separate days. Is that legit?