### PR TITLE
Fix commit verification null exception

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/Grader.java
+++ b/src/main/java/edu/byu/cs/autograder/Grader.java
@@ -83,7 +83,7 @@ public class Grader implements Runnable {
         try {
             // FIXME: remove this sleep. currently the grader is too quick for the client to keep up
             Thread.sleep(1000);
-            CommitVerificationResult commitVerificationResult = gitHelper.setUp();
+            CommitVerificationResult commitVerificationResult = gitHelper.setUpAndVerifyHistory();
             dbHelper.setUp();
             if (RUN_COMPILATION) compileHelper.compile();
 

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -151,7 +151,7 @@ public class GitHelper {
         }
 
         // We have a previous result to defer to:
-        Submission.ScoreVerification scoreVerification = firstPassingSubmission.verification();
+        int originalPenaltyPct = firstPassingSubmission.getPenaltyPct();
         boolean verified = firstPassingSubmission.verifiedStatus() != Submission.VerifiedStatus.Unapproved;
         String message = verified ?
                 "You passed the commit verification on your first passing submission! You're good to go!" :
@@ -159,7 +159,7 @@ public class GitHelper {
                     "You still need to meet with a TA or a professor to gain credit for this phase.";
         return new CommitVerificationResult(
                 verified, true,
-                0, 0, 0, scoreVerification.penaltyPct(), message,
+                0, 0, 0, originalPenaltyPct, message,
                 null, null,
                 firstPassingSubmission.headHash(), null
         );

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -97,7 +97,10 @@ public class GitHelper {
         String headHash = getHeadHash(stageRepo);
         return skipCommitVerification(verified, headHash, null);
     }
-    private CommitVerificationResult skipCommitVerification(boolean verified, String headHash, String failureMessage) {
+    private CommitVerificationResult skipCommitVerification(boolean verified, @NonNull String headHash, String failureMessage) {
+        if (headHash == null) {
+            throw new IllegalArgumentException("Head hash cannot be null");
+        }
         LOGGER.debug("Skipping commit verification. Verified: {}", verified);
         return new CommitVerificationResult(
                 verified, false,

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -152,7 +152,7 @@ public class GitHelper {
 
         // We have a previous result to defer to:
         int originalPenaltyPct = firstPassingSubmission.getPenaltyPct();
-        boolean verified = firstPassingSubmission.verifiedStatus() != Submission.VerifiedStatus.Unapproved;
+        boolean verified = firstPassingSubmission.verifiedStatus().isApproved();
         String message = verified ?
                 "You passed the commit verification on your first passing submission! You're good to go!" :
                 "You have previously failed commit verification.\n"+

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -55,13 +55,10 @@ public class GitHelper {
             throw new RuntimeException("Cannot verifyCommitHistory before headHash has been populated. Call setUp() first.");
         }
 
-        File stageRepo = gradingContext.stageRepo();
         try {
-            boolean requiresVerification = PhaseUtils.isPhaseGraded(gradingContext.phase()) && !gradingContext.admin();
-            if (!requiresVerification) {
-                return skipCommitVerification(true, headHash, null);
-            }
-            return verifyCommitRequirements(stageRepo);
+            return shouldVerifyCommits() ?
+                    verifyCommitRequirements(gradingContext.stageRepo()) :
+                    skipCommitVerification(true, headHash, null);
         } catch (GradingException e) {
             // Grading can continue, we'll just alert them of the error.
             String errorStr = "Internally failed to evaluate commit history: " + e.getMessage();
@@ -69,6 +66,15 @@ public class GitHelper {
             LOGGER.error("Failed to evaluate commit history", e);
             return skipCommitVerification(false, headHash, errorStr);
         }
+    }
+
+    /**
+     * Determines if the current grading context requires verifying the commit history.
+     *
+     * @return True if the commits should be verified; otherwise, false.
+     */
+    private boolean shouldVerifyCommits() {
+        return !gradingContext.admin() && PhaseUtils.isPhaseGraded(gradingContext.phase());
     }
 
     /**

--- a/src/main/java/edu/byu/cs/model/Submission.java
+++ b/src/main/java/edu/byu/cs/model/Submission.java
@@ -95,7 +95,11 @@ public record Submission(
         Unapproved,
         ApprovedAutomatically,
         ApprovedManually,
-        PreviouslyApproved,
+        PreviouslyApproved;
+
+        public boolean isApproved() {
+            return this != VerifiedStatus.Unapproved;
+        }
     }
 
     @Override

--- a/src/main/java/edu/byu/cs/model/Submission.java
+++ b/src/main/java/edu/byu/cs/model/Submission.java
@@ -111,6 +111,21 @@ public record Submission(
         return Objects.hash(netId, headHash, phase);
     }
 
+    /**
+     * Returns the penalty percentage within a submission, or 0 if it doesn't exist.
+     * <br>
+     * The existence of the penalty pct doesn't necessarily mean it should be applied.
+     * Make sure to respect other related status flags. When needed, this will give a value.
+     *
+     * @return An int representing the penalty pct.
+     */
+    public int getPenaltyPct() {
+        if (verification == null || verification.penaltyPct() == null) {
+            return 0;
+        }
+        return verification.penaltyPct();
+    }
+
     public static String serializeScoreVerification(@NonNull Submission submission) {
         return serializeScoreVerification(submission.verification);
     }


### PR DESCRIPTION
## Overview
This fixes the null pointer exception that occurred in the commit verification process when students resubmitted their phase after a blocked submission but before it was manually approved.

### Complete Solution
Beyond simply fixing the error, it also introduces improved error handling so that future errors will be caught and reported, but grading will still continue and the submission can still be saved in the database. Additionally, the call signatures of related functions have been adjusted to minimize the possibility of null pointer issues in the future.

Key adjustments are the titles of each commit in the PR.

## Notifying Error Message
This is the sample exception it will resolve:
```bash
java.lang.NullPointerException: Cannot invoke "edu.byu.cs.model.Submission$ScoreVerification.penaltyPct()" because "scoreVerification" is null
        at edu.byu.cs.autograder.git.GitHelper.preserveOriginalVerification(GitHelper.java:128)
        at edu.byu.cs.autograder.git.GitHelper.verifyCommitRequirements(GitHelper.java:88)
        at edu.byu.cs.autograder.git.GitHelper.setUp(GitHelper.java:49)
        at edu.byu.cs.autograder.Grader.run(Grader.java:86)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```