### PR TITLE
Lower commit threshold to 5 changes in discussion with Prof. Wilkerson

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/Grader.java
+++ b/src/main/java/edu/byu/cs/autograder/Grader.java
@@ -64,7 +64,7 @@ public class Grader implements Runnable {
         int requiredCommits = 10;
         int requiredDaysWithCommits = 3;
         int commitVerificationPenaltyPct = 10;
-        int minimumChangedLinesPerCommit = 20;
+        int minimumChangedLinesPerCommit = 5;
 
         this.observer = observer;
         this.gradingContext = new GradingContext(


### PR DESCRIPTION
This change is only necessary in one place because of the way the commit verification has been organized.