### PR TITLE
Disable canvas and compilation

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -30,6 +30,7 @@ services:
         "--cas-callback-url", "changeme",
         "--canvas-token", "changeme",
         "--use-canvas", "true",
+#        "--disable-compilation", # Enable me, if desired!
     ]
     networks:
       - autograder

--- a/src/main/java/edu/byu/cs/autograder/Grader.java
+++ b/src/main/java/edu/byu/cs/autograder/Grader.java
@@ -32,7 +32,7 @@ public class Grader implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(Grader.class);
 
     /** DEV ONLY. Default: true. Skips compilation and evaluation of student projects. */
-    private static final boolean RUN_COMPILATION = ApplicationProperties.runCompilation();
+    private final boolean RUN_COMPILATION = ApplicationProperties.runCompilation();
 
     private final DatabaseHelper dbHelper;
 

--- a/src/main/java/edu/byu/cs/autograder/Grader.java
+++ b/src/main/java/edu/byu/cs/autograder/Grader.java
@@ -13,6 +13,7 @@ import edu.byu.cs.autograder.test.UnitTestGrader;
 import edu.byu.cs.dataAccess.DataAccessException;
 import edu.byu.cs.model.*;
 import edu.byu.cs.dataAccess.DaoService;
+import edu.byu.cs.properties.ApplicationProperties;
 import edu.byu.cs.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +32,7 @@ public class Grader implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(Grader.class);
 
     /** DEV ONLY. Default: true. Skips compilation and evaluation of student projects. */
-    private static final boolean RUN_COMPILATION = true;
+    private static final boolean RUN_COMPILATION = ApplicationProperties.runCompilation();
 
     private final DatabaseHelper dbHelper;
 

--- a/src/main/java/edu/byu/cs/autograder/Grader.java
+++ b/src/main/java/edu/byu/cs/autograder/Grader.java
@@ -87,7 +87,7 @@ public class Grader implements Runnable {
             dbHelper.setUp();
             if (RUN_COMPILATION) compileHelper.compile();
 
-            new PreviousPhasePassoffTestGrader(gradingContext).runTests();
+            if (RUN_COMPILATION) new PreviousPhasePassoffTestGrader(gradingContext).runTests();
 
             RubricConfig rubricConfig = DaoService.getRubricConfigDao().getRubricConfig(gradingContext.phase());
             var evaluationResults = evaluateProject(RUN_COMPILATION ? rubricConfig : null);

--- a/src/main/java/edu/byu/cs/autograder/score/LateDayCalculator.java
+++ b/src/main/java/edu/byu/cs/autograder/score/LateDayCalculator.java
@@ -6,6 +6,7 @@ import edu.byu.cs.canvas.CanvasService;
 import edu.byu.cs.dataAccess.DaoService;
 import edu.byu.cs.dataAccess.DataAccessException;
 import edu.byu.cs.model.Phase;
+import edu.byu.cs.properties.ApplicationProperties;
 import edu.byu.cs.util.PhaseUtils;
 import org.eclipse.jgit.annotations.NonNull;
 import org.eclipse.jgit.annotations.Nullable;
@@ -41,8 +42,9 @@ public class LateDayCalculator {
     }
 
     public int calculateLateDays(Phase phase, String netId) throws GradingException, DataAccessException {
-        int assignmentNum = PhaseUtils.getPhaseAssignmentNumber(phase);
+        if (!ApplicationProperties.useCanvas()) return 0;
 
+        int assignmentNum = PhaseUtils.getPhaseAssignmentNumber(phase);
         int canvasUserId = DaoService.getUserDao().getUser(netId).canvasUserId();
 
         ZonedDateTime dueDate;

--- a/src/main/java/edu/byu/cs/autograder/score/Scorer.java
+++ b/src/main/java/edu/byu/cs/autograder/score/Scorer.java
@@ -11,6 +11,7 @@ import edu.byu.cs.canvas.model.CanvasRubricItem;
 import edu.byu.cs.canvas.model.CanvasSubmission;
 import edu.byu.cs.dataAccess.*;
 import edu.byu.cs.model.*;
+import edu.byu.cs.properties.ApplicationProperties;
 import edu.byu.cs.util.PhaseUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,6 +80,12 @@ public class Scorer {
             Rubric rubric, CommitVerificationResult commitVerificationResult,
             int daysLate, float thisScore
     ) throws DataAccessException, GradingException {
+
+        if (!ApplicationProperties.useCanvas()) {
+            return saveResults(rubric, commitVerificationResult, daysLate, thisScore,
+                    "Would have attempted grade-book submission, but skipped due to application properties.");
+        }
+
         int canvasUserId = getCanvasUserId();
         int assignmentNum = PhaseUtils.getPhaseAssignmentNumber(gradingContext.phase());
 

--- a/src/main/java/edu/byu/cs/properties/ApplicationProperties.java
+++ b/src/main/java/edu/byu/cs/properties/ApplicationProperties.java
@@ -67,4 +67,8 @@ public class ApplicationProperties {
     public static boolean useCanvas() {
         return Boolean.parseBoolean(get("use-canvas", "true"));
     }
+
+    public static boolean runCompilation() {
+        return Boolean.parseBoolean(get("run-compilation", "true"));
+    }
 }

--- a/src/main/java/edu/byu/cs/server/Server.java
+++ b/src/main/java/edu/byu/cs/server/Server.java
@@ -151,6 +151,9 @@ public class Server {
             if (cmd.hasOption("use-canvas")) {
                 properties.setProperty("use-canvas", cmd.getOptionValue("use-canvas"));
             }
+            if (cmd.hasOption("disable-compilation")) {
+                properties.setProperty("run-compilation", "false");
+            }
         } catch (ParseException e) {
             throw new RuntimeException("Error parsing command line arguments", e);
         }
@@ -169,6 +172,7 @@ public class Server {
         options.addOption(null, "cas-callback-url", true, "CAS Callback URL");
         options.addOption(null, "canvas-token", true, "Canvas Token");
         options.addOption(null, "use-canvas", true, "Using Canvas");
+        options.addOption(null, "disable-compilation", false, "Turn off student code compilation");
         return options;
     }
 


### PR DESCRIPTION
This PR continues efforts begun in #328 by adding guards to newly added method calls. It also leverages the newly added `ApplicationProperties` system to read in the values from a properties file.