### PR TITLE
Only count completed extra credit in notes

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/test/PassoffTestGrader.java
+++ b/src/main/java/edu/byu/cs/autograder/test/PassoffTestGrader.java
@@ -75,7 +75,7 @@ public class PassoffTestGrader extends TestGrader {
 
         Map<String, Float> ecScores = getECScores(testResults);
         float extraCreditValue = PhaseUtils.extraCreditValue(gradingContext.phase());
-        float totalECPoints = ecScores.values().stream().reduce(0f, Float::sum) * extraCreditValue;
+        float totalECPoints = ecScores.values().stream().reduce(0f, (f1, f2) -> (float) (f1 + Math.floor(f2))) * extraCreditValue;
 
         if (totalECPoints > 0f) notes.append("\nExtra credit tests: +").append(totalECPoints * 100).append("%");
 


### PR DESCRIPTION
This fixes a calculation where students are receiving notes like "Extra credit tests: +5.6%" (had done 1/2 extra credit) and "Extra credit tests: +2.4%" (had done no extra credit). This will be replaced with the correct number (no extra credit display/4%/8%)