### PR TITLE
Suppress expected warning output in tests

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/score/LateDayCalculator.java
+++ b/src/main/java/edu/byu/cs/autograder/score/LateDayCalculator.java
@@ -104,27 +104,52 @@ public class LateDayCalculator {
      * @param encodedPublicHolidays A string representing the encoded data.
      */
     public Set<LocalDate> initializePublicHolidays(@NonNull String encodedPublicHolidays) {
-        return initializePublicHolidays(encodedPublicHolidays, "M/d/yyyy");
+        return initializePublicHolidays(encodedPublicHolidays, false);
+    }
+    /**
+     * Initializes our public holidays with a common formatting string
+     * that will accept strings matching this example: "9/16/2024"
+     *
+     * @see #initializePublicHolidays(String, String, boolean)
+     *
+     * @param encodedPublicHolidays A string representing the encoded data.
+     */
+    public Set<LocalDate> initializePublicHolidays(@NonNull String encodedPublicHolidays, boolean quietWarnings) {
+        return initializePublicHolidays(encodedPublicHolidays, "M/d/yyyy", quietWarnings);
     }
 
     /**
      * Initializes our internal public holidays data set with the given string and a given date format.
      * This method also returns the constructed set of dates.
-     *
+     * <br>
      * This must be called before calls to {@code getNumDaysLate()} will properly account for the holidays.
      *
-     * @see #interpretPublicHolidays(String, String)
+     * @see #interpretPublicHolidays(String, String, boolean)
      *
      * @param encodedPublicHolidays @non-nullable A string representing the configured data
      * @param dateEncodingFormat A string representing the intended date format within the data
      */
     public Set<LocalDate> initializePublicHolidays(@NonNull String encodedPublicHolidays, @NonNull String dateEncodingFormat) {
+        return initializePublicHolidays(encodedPublicHolidays, dateEncodingFormat, false);
+    }
+    /**
+     * Initializes our internal public holidays data set with the given string and a given date format.
+     * This method also returns the constructed set of dates.
+     * <br>
+     * This must be called before calls to {@code getNumDaysLate()} will properly account for the holidays.
+     *
+     * @see #interpretPublicHolidays(String, String, boolean)
+     *
+     * @param encodedPublicHolidays @non-nullable A string representing the configured data
+     * @param dateEncodingFormat A string representing the intended date format within the data
+     */
+    public Set<LocalDate> initializePublicHolidays(@NonNull String encodedPublicHolidays, @NonNull String dateEncodingFormat, boolean quietWarnings) {
         if (encodedPublicHolidays == null || dateEncodingFormat == null) {
             throw new RuntimeException("Error initializing public holidays. Received null as a parameter. " +
                     "If some data isn't available, explicitly call the no argument initializer instead.");
         }
 
-        publicHolidays = interpretPublicHolidays(encodedPublicHolidays, dateEncodingFormat);
+        publicHolidays = interpretPublicHolidays(encodedPublicHolidays, dateEncodingFormat, quietWarnings);
         // TODO: Validate that some holidays are configured for the current calendar year and throw an error otherwise
         return publicHolidays;
     }
@@ -175,9 +200,10 @@ public class LateDayCalculator {
      *                              depending on the most convenient form of maintaining this information.
      * @param dateEncodingFormat A string representing the date format.
      *                           This will be interpreted by {@link DateTimeFormatter}.
+     * @param quietWarnings Option to quiet warnings instead of sending them to STDERR.
      * @return A {@code Set<Date>} that will be used to efficiently comparing against this dataset
      */
-    private Set<LocalDate> interpretPublicHolidays(@Nullable String encodedPublicHolidays, @NonNull String dateEncodingFormat) {
+    private Set<LocalDate> interpretPublicHolidays(@Nullable String encodedPublicHolidays, @NonNull String dateEncodingFormat, boolean quietWarnings) {
         String[] dateStrings;
         if (encodedPublicHolidays == null) {
             dateStrings = new String[]{};
@@ -187,7 +213,7 @@ public class LateDayCalculator {
             dateStrings = extractPublicHolidaysSingleline(encodedPublicHolidays);
         }
 
-        return parsePublicHolidayStrings(dateEncodingFormat, dateStrings, false);
+        return parsePublicHolidayStrings(dateEncodingFormat, dateStrings, quietWarnings);
     }
     private String[] extractPublicHolidaysSingleline(String singleLineEncodedHolidays) {
         String DELIMITERS = " ,;";

--- a/src/main/java/edu/byu/cs/autograder/score/LateDayCalculator.java
+++ b/src/main/java/edu/byu/cs/autograder/score/LateDayCalculator.java
@@ -187,7 +187,7 @@ public class LateDayCalculator {
             dateStrings = extractPublicHolidaysSingleline(encodedPublicHolidays);
         }
 
-        return parsePublicHolidayStrings(dateEncodingFormat, dateStrings);
+        return parsePublicHolidayStrings(dateEncodingFormat, dateStrings, false);
     }
     private String[] extractPublicHolidaysSingleline(String singleLineEncodedHolidays) {
         String DELIMITERS = " ,;";
@@ -202,7 +202,7 @@ public class LateDayCalculator {
         }
         return holidays.toArray(new String[0]);
     }
-    private Set<LocalDate> parsePublicHolidayStrings(@NonNull String dateFormat, String[] holidayDateStrings) {
+    private Set<LocalDate> parsePublicHolidayStrings(@NonNull String dateFormat, String[] holidayDateStrings, boolean quietWarnings) {
         Set<LocalDate> publicHolidays = new HashSet<>();
         var parser = DateTimeFormatter.ofPattern(dateFormat);
         for (var holidayDateString : holidayDateStrings) {
@@ -215,7 +215,7 @@ public class LateDayCalculator {
             try {
                 publicHolidays.add(parser.parse(holidayDateString, LocalDate::from));
             } catch (DateTimeParseException e) {
-                LOGGER.warning("Skipping unrecognized date string: " + holidayDateString);
+                if (!quietWarnings) LOGGER.warning("Skipping unrecognized date string: " + holidayDateString);
             }
         }
         return publicHolidays;

--- a/src/test/java/edu/byu/cs/autograder/score/LateDayCalculatorTest.java
+++ b/src/test/java/edu/byu/cs/autograder/score/LateDayCalculatorTest.java
@@ -10,6 +10,14 @@ import java.time.format.DateTimeFormatter;
 
 class LateDayCalculatorTest {
 
+    /**
+     * To be enabled in production.
+     * Removes the warning output since the tests are expected to pass in faulty input values.
+     * <br>
+     * Disable during debugging.
+     */
+    private static final boolean QUIET_HOLIDAY_INIT_WARNINGS = true;
+
     @Test
     void getNumDaysLateWithoutHolidays() {
         // Initialize without holidays
@@ -70,7 +78,7 @@ class LateDayCalculatorTest {
     void getNumDaysLateWithHolidays() {
         // Initialize with holidays
         LateDayCalculator standardlateDayCalculator = new LateDayCalculator();
-        standardlateDayCalculator.initializePublicHolidays(getMultilinePublicHolidaysConfiguration());
+        standardlateDayCalculator.initializePublicHolidays(getMultilinePublicHolidaysConfiguration(), QUIET_HOLIDAY_INIT_WARNINGS);
 
         // See image: days-late-with-holidays-common
         String commonDueDate = "2024-03-07 11:59:00 PM -07:00";
@@ -142,7 +150,7 @@ class LateDayCalculatorTest {
 
         // See image: days-late-with-holidays-friday-holiday-and-consecutive-holidays
         LateDayCalculator customlateDayCalculator = new LateDayCalculator();
-        customlateDayCalculator.initializePublicHolidays("12/20/2024;12/24/2024;12/25/2024;12/31/2024;1/1/2025");
+        customlateDayCalculator.initializePublicHolidays("12/20/2024;12/24/2024;12/25/2024;12/31/2024;1/1/2025", QUIET_HOLIDAY_INIT_WARNINGS);
         String fridayHolidayDueDate = "2024-12-20 11:59:00 PM -07:00";
         ExpectedDaysLate[] fridayHolidayAndConsecutiveHolidays = {
                 // On Time
@@ -184,7 +192,7 @@ class LateDayCalculatorTest {
 
         // See image: days-late-with-holidays-holidays-on-weekends
         LateDayCalculator customlateDayCalculator2 = new LateDayCalculator();
-        customlateDayCalculator2.initializePublicHolidays("09/16/2028;09/17/2028;09/18/2028;");
+        customlateDayCalculator2.initializePublicHolidays("09/16/2028;09/17/2028;09/18/2028;", QUIET_HOLIDAY_INIT_WARNINGS);
         String holidaysOnWeekendsDueDate = "2028-09-14 02:15:00 PM -07:00";
         ExpectedDaysLate[] holidaysOnWeekends = {
                 new ExpectedDaysLate("2028-09-14 02:15:00 PM -07:00", 0), // Due date
@@ -263,7 +271,7 @@ class LateDayCalculatorTest {
     }
     private void validateExpectedHolidays(String encodedPublicHolidays) {
         LateDayCalculator lateDayCalculator = new LateDayCalculator();
-        var initializedPublicHolidays = lateDayCalculator.initializePublicHolidays(encodedPublicHolidays);
+        var initializedPublicHolidays = lateDayCalculator.initializePublicHolidays(encodedPublicHolidays, QUIET_HOLIDAY_INIT_WARNINGS);
 
         Assertions.assertEquals(17, initializedPublicHolidays.size(),
                 "Set does not have the right number of public holidays");


### PR DESCRIPTION
Previously, the `LateDayCalculatorTest`'s would generate error output as they intentionally fed poorly formatted data to the functions and tested the results. While we do intend to warn developers as they work on these kinds of adjustments, it is not good practice to have error output hitting the console when the tests run.

The PR introduces a new quiet mode that addresses this problem. The tests use overloads of the methods that enable them to disable the warning output, but the production code still runs with the output enabled.