### PR TITLE
Modified test files ignore phase quality

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/compile/ModifiedTestFilesVerifier.java
+++ b/src/main/java/edu/byu/cs/autograder/compile/ModifiedTestFilesVerifier.java
@@ -104,7 +104,10 @@ public class ModifiedTestFilesVerifier implements StudentCodeVerifier {
      * @param phase Phase to grab the test files from.
      * @return A map of the phase's file names and the associated absolute path to that file.
      */
-    private Map<String, String> getPhasePassoffFileNamesToAbsolutePath(String phasesPath, Phase phase) {
+    private Map<String, String> getPhasePassoffFileNamesToAbsolutePath(
+            String phasesPath,
+            Phase phase
+    ) throws GradingException {
         String phaseNumber = PhaseUtils.getPhaseAsString(phase);
         String passoffPath = String.format("%s/phase%s/passoff/", phasesPath, phaseNumber);
         return FileUtils.getFileNamesToAbsolutePaths(Path.of(passoffPath));

--- a/src/main/java/edu/byu/cs/autograder/compile/ModifiedTestFilesVerifier.java
+++ b/src/main/java/edu/byu/cs/autograder/compile/ModifiedTestFilesVerifier.java
@@ -6,8 +6,6 @@ import edu.byu.cs.model.Phase;
 import edu.byu.cs.util.FileUtils;
 import edu.byu.cs.util.PhaseUtils;
 import edu.byu.cs.util.ProcessUtils;
-
-
 import java.nio.file.Path;
 import java.util.*;
 
@@ -42,17 +40,16 @@ public class ModifiedTestFilesVerifier implements StudentCodeVerifier {
      */
     @Override
     public void verify(GradingContext context, StudentCodeReader reader) throws GradingException {
-        modifiedFiles.clear();
-        missingFiles.clear();
+        if (!PhaseUtils.isPhaseGraded(context.phase())) return;
 
         // check for modified or missing files
         Map<String, String> studentTestFileNames = getStudentPassoffFileNamesToAbsolutePath(reader);
         Phase currentPhase = context.phase();
         do {
-            Map<String, String> referenceTestFileNames =
+            Map<String, String> referencePhaseFileNames =
                     getPhasePassoffFileNamesToAbsolutePath(context.phasesPath(), currentPhase);
             try {
-                comparePhaseReferencePassoffFilesToStudent(referenceTestFileNames, studentTestFileNames);
+                comparePhaseReferencePassoffFilesToStudent(referencePhaseFileNames, studentTestFileNames);
             } catch (ProcessUtils.ProcessException e) {
                 throw new GradingException("Unable to verify unmodified test files: " + e.getMessage());
             }
@@ -72,6 +69,8 @@ public class ModifiedTestFilesVerifier implements StudentCodeVerifier {
                     missingFiles.isEmpty() ? "None" : String.join(", ", missingFiles)
             );
             context.observer().notifyWarning(warningMessage);
+            modifiedFiles.clear();
+            missingFiles.clear();
         }
     }
 
@@ -95,7 +94,7 @@ public class ModifiedTestFilesVerifier implements StudentCodeVerifier {
     }
 
     /**
-     * Gets all the phases's test file names based on the phase number and path to the phases folder
+     * Gets all the phases' test file names based on the phase number and path to the phases folder
      * containing those files.
      * Format:
      * {

--- a/src/main/java/edu/byu/cs/util/FileUtils.java
+++ b/src/main/java/edu/byu/cs/util/FileUtils.java
@@ -200,7 +200,9 @@ public class FileUtils {
                 }
             }
         } catch (IOException e) {
-            return null;
+            throw new RuntimeException(
+                    String.format("Could not find file names given %s: %s", filePath, e.getMessage())
+            );
         }
         return fileNamesToAbsolutesPaths;
     }

--- a/src/main/java/edu/byu/cs/util/FileUtils.java
+++ b/src/main/java/edu/byu/cs/util/FileUtils.java
@@ -1,5 +1,6 @@
 package edu.byu.cs.util;
 
+import edu.byu.cs.autograder.GradingException;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
@@ -188,7 +189,7 @@ public class FileUtils {
      *     "IdeaProjects/autograder/phases/phase0/passoff/chess/ChessBoardTests.java"
      * }
      */
-    public static Map<String, String> getFileNamesToAbsolutePaths(Path filePath) {
+    public static Map<String, String> getFileNamesToAbsolutePaths(Path filePath) throws GradingException {
         Map<String, String> fileNamesToAbsolutesPaths = new HashMap<>();
         try (Stream<Path> paths = Files.walk(filePath)) {
             for (Path path : paths.toList()) {
@@ -200,7 +201,7 @@ public class FileUtils {
                 }
             }
         } catch (IOException e) {
-            throw new RuntimeException(
+            throw new GradingException(
                     String.format("Could not find file names given %s: %s", filePath, e.getMessage())
             );
         }


### PR DESCRIPTION
Quick bug fix for not running the modified test files verifier on code quality and making a helper method throw a runtime exception instead of returning null.