### PR TITLE
Fix XML file not created error

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/test/TestAnalyzer.java
+++ b/src/main/java/edu/byu/cs/autograder/test/TestAnalyzer.java
@@ -29,6 +29,10 @@ public class TestAnalyzer {
         TestNode extraCredit = new TestNode();
         extraCredit.setTestName("JUnit Jupiter Extra Credit");
 
+        if(!junitXmlOutput.exists()) {
+            return compileAnalysis(root, extraCredit, error);
+        }
+
         String xml = FileUtils.readStringFromFile(junitXmlOutput);
         TestSuite suite;
         try {
@@ -74,11 +78,7 @@ public class TestAnalyzer {
             }
         }
 
-        TestNode.collapsePackages(root);
-        TestNode.countTests(root);
-        TestNode.collapsePackages(extraCredit);
-        TestNode.countTests(extraCredit);
-        return new TestAnalysis(root, extraCredit, error);
+        return compileAnalysis(root, extraCredit, error);
     }
 
     private TestNode nodeForClass(TestNode base, String name) {
@@ -97,5 +97,13 @@ public class TestAnalyzer {
 
         if(extra == null) return node;
         else return nodeForClass(node, extra);
+    }
+
+    private TestAnalysis compileAnalysis(TestNode root, TestNode extraCredit, String error) {
+        TestNode.collapsePackages(root);
+        TestNode.countTests(root);
+        TestNode.collapsePackages(extraCredit);
+        TestNode.countTests(extraCredit);
+        return new TestAnalysis(root, extraCredit, error);
     }
 }


### PR DESCRIPTION
If an exception is thrown from a BeforeAll annotated method junit does not create the output xml file. As a result, an exception is thrown, and the true cause of the error is not reported to the student. This adds a check for the file existing and exits early if it does not. The student will be able to see the stack trace of the error as it will be in the junit process error output