### PR TITLE
Add verification of running with port argument 0

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/compile/CompileHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/compile/CompileHelper.java
@@ -5,10 +5,7 @@ import edu.byu.cs.autograder.GradingException;
 import edu.byu.cs.autograder.compile.modifiers.PassoffJarModifier;
 import edu.byu.cs.autograder.compile.modifiers.PomModifier;
 import edu.byu.cs.autograder.compile.modifiers.TestFactoryModifier;
-import edu.byu.cs.autograder.compile.verifers.ModifiedTestFilesVerifier;
-import edu.byu.cs.autograder.compile.verifers.ModuleIndependenceVerifier;
-import edu.byu.cs.autograder.compile.verifers.ProjectStructureVerifier;
-import edu.byu.cs.autograder.compile.verifers.TestLocationVerifier;
+import edu.byu.cs.autograder.compile.verifers.*;
 import edu.byu.cs.util.ProcessUtils;
 
 import java.io.IOException;
@@ -24,7 +21,7 @@ public class CompileHelper {
 
     private final Collection<StudentCodeVerifier> currentVerifiers =
             List.of(new ProjectStructureVerifier(), new ModuleIndependenceVerifier(), new ModifiedTestFilesVerifier(),
-                    new TestLocationVerifier());
+                    new TestLocationVerifier(), new ServerFacadeTestPortVerifier());
 
 
     private final Collection<StudentCodeModifier> currentModifiers =

--- a/src/main/java/edu/byu/cs/autograder/compile/verifers/ServerFacadeTestPortVerifier.java
+++ b/src/main/java/edu/byu/cs/autograder/compile/verifers/ServerFacadeTestPortVerifier.java
@@ -1,0 +1,53 @@
+package edu.byu.cs.autograder.compile.verifers;
+
+import edu.byu.cs.autograder.GradingContext;
+import edu.byu.cs.autograder.GradingException;
+import edu.byu.cs.autograder.compile.StudentCodeReader;
+import edu.byu.cs.autograder.compile.StudentCodeVerifier;
+import edu.byu.cs.model.Phase;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ServerFacadeTestPortVerifier implements StudentCodeVerifier {
+    private static final String DYNAMIC_PORT_LINE = "port = server.run(0)";
+    private static final int CHECK_HARDCODED_PORT = 8080;
+    private static final String EXPLANATION = "A port argument of 0 lets Spark/Jetty choose a port. The run method " +
+            "then returns the port the server started on. Use this return value to set up your server facade " +
+            "(probably \"var port\").";
+
+    @Override
+    public void verify(GradingContext context, StudentCodeReader reader) throws GradingException {
+        if(context.phase() != Phase.Phase5) return;
+
+        try {
+            Set<File> testFiles = reader.filesMatching(".*client/src/test/java/.*").collect(Collectors.toSet());
+            boolean hardCodedPortFound = false;
+            boolean dynamicPortLineMissing = true;
+            for(File file : testFiles) {
+                for(String line : reader.getFileContents(file)) {
+                    if (line.contains(String.valueOf(CHECK_HARDCODED_PORT))) {
+                        hardCodedPortFound = true;
+                    }
+                    if(line.contains(DYNAMIC_PORT_LINE)) {
+                        dynamicPortLineMissing = false;
+                    }
+                }
+            }
+
+            if(hardCodedPortFound) {
+                context.observer().notifyWarning(String.format("Found hardcoded number (probably port) %d in client " +
+                        "tests. Please adjust to pass in 0 (zero) as the port. %s", CHECK_HARDCODED_PORT, EXPLANATION));
+            }
+            else if(dynamicPortLineMissing) {
+                context.observer().notifyWarning(String.format("Could not locate a line matching %s in client tests " +
+                        "from the starter code. Please ensure server run parameter is 0. %s", DYNAMIC_PORT_LINE, EXPLANATION));
+            }
+        } catch (IOException e) {
+            throw new GradingException("Could not read file contents", e);
+        }
+
+    }
+}


### PR DESCRIPTION
This adds another verifier that checks for students hardcoding port 8080 and seeing if it can find a line of code matching `port = server.run(0)`. It then warns the student if it can find 8080 somewhere or can't find the target string