### PR TITLE
Only display warning if message is not blank in test location verifier

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/compile/verifers/TestLocationVerifier.java
+++ b/src/main/java/edu/byu/cs/autograder/compile/verifers/TestLocationVerifier.java
@@ -75,8 +75,11 @@ public class TestLocationVerifier implements StudentCodeVerifier {
             }
             currPhase = PhaseUtils.getPreviousPhase(currPhase);
         } while (currPhase != null);
-
-        context.observer().notifyWarning(buildMessage());
+        
+        String message = buildMessage();
+        if (!message.isBlank()) {
+            context.observer().notifyWarning(message);
+        }
 
         missingPackages.clear();
         foundFiles.clear();


### PR DESCRIPTION
Added a check to only notify the observer if the message is not blank (instead of potentially warning them with an empty warning message. Yeah, I'm something of a programmer)