### PR TITLE
382 backend record instances of previous tests failing in submission table

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/Grader.java
+++ b/src/main/java/edu/byu/cs/autograder/Grader.java
@@ -80,10 +80,11 @@ public class Grader implements Runnable {
 
     public void run() {
         observer.notifyStarted();
+        CommitVerificationResult commitVerificationResult = null;
         try {
             // FIXME: remove this sleep. currently the grader is too quick for the client to keep up
             Thread.sleep(1000);
-            CommitVerificationResult commitVerificationResult = gitHelper.setUpAndVerifyHistory();
+            commitVerificationResult = gitHelper.setUpAndVerifyHistory();
             dbHelper.setUp();
             if (RUN_COMPILATION) {
                 compileHelper.compile();
@@ -97,16 +98,9 @@ public class Grader implements Runnable {
             DaoService.getSubmissionDao().insertSubmission(submission);
 
             observer.notifyDone(submission);
-        } catch (GradingException ge) {
-            if(ge.getDetails() != null) observer.notifyError(ge.getMessage(), ge.getDetails());
-            else if (ge.getAnalysis() != null) observer.notifyError(ge.getMessage(), ge.getAnalysis());
-            else observer.notifyError(ge.getMessage());
-            String notification =
-                    "Error running grader for user " + gradingContext.netId() + " and repository " + gradingContext.repoUrl();
-            if(ge.getDetails() != null) notification += ". Details:\n" + ge.getDetails();
-            LOGGER.error(notification, ge);
         } catch (Exception e) {
-            observer.notifyError(e.getMessage());
+            GradingException ge = e instanceof GradingException ? (GradingException) e : new GradingException(e);
+            handleException(ge, commitVerificationResult);
             LOGGER.error("Error running grader for user {} and repository {}", gradingContext.netId(),
                     gradingContext.repoUrl(), e);
         } finally {
@@ -128,7 +122,7 @@ public class Grader implements Runnable {
                     case PASSOFF_TESTS -> new PassoffTestGrader(gradingContext).runTests();
                     case UNIT_TESTS -> new UnitTestGrader(gradingContext).runTests();
                     case QUALITY -> new QualityGrader(gradingContext).runQualityChecks();
-                    case GIT_COMMITS, PREVIOUS_TESTS -> null;
+                    case GIT_COMMITS, GRADING_ISSUE -> null;
                 };
                 if (results != null) {
                     rubricItems.put(type, new Rubric.RubricItem(configItem.category(), results, configItem.criteria()));
@@ -167,4 +161,20 @@ public class Grader implements Runnable {
         }
         throw new GradingException("Could not find github username and repository name given '" + repoUrl + "'.");
     }
+
+
+    private void handleException(GradingException ge, CommitVerificationResult cvr) {
+        if(cvr == null) {
+            observer.notifyError(ge.getMessage());
+            return;
+        }
+        try {
+            Submission submission = new Scorer(gradingContext).generateSubmissionObject(ge.asRubric(), cvr, 0, 0f, ge.getMessage());
+            DaoService.getSubmissionDao().insertSubmission(submission);
+            observer.notifyDone(submission);
+        } catch (GradingException | DataAccessException ex) {
+            observer.notifyError(ex.getMessage());
+        }
+    }
+
 }

--- a/src/main/java/edu/byu/cs/autograder/Grader.java
+++ b/src/main/java/edu/byu/cs/autograder/Grader.java
@@ -171,9 +171,9 @@ public class Grader implements Runnable {
         try {
             Submission submission = new Scorer(gradingContext).generateSubmissionObject(ge.asRubric(), cvr, 0, 0f, ge.getMessage());
             DaoService.getSubmissionDao().insertSubmission(submission);
-            observer.notifyDone(submission);
-        } catch (GradingException | DataAccessException ex) {
-            observer.notifyError(ex.getMessage());
+            observer.notifyError(ge.getMessage(), submission);
+        } catch (Exception ex) {
+            observer.notifyError(ex.getMessage() + "\n" + ge.getMessage());
         }
     }
 

--- a/src/main/java/edu/byu/cs/autograder/GradingException.java
+++ b/src/main/java/edu/byu/cs/autograder/GradingException.java
@@ -1,10 +1,16 @@
 package edu.byu.cs.autograder;
 
+import edu.byu.cs.model.Rubric;
 import edu.byu.cs.model.TestAnalysis;
 
+import java.util.EnumMap;
+import java.util.Map;
+
 public class GradingException extends Exception{
-    private String details;
-    private TestAnalysis analysis;
+    private static final String CATEGORY = "Grading Issue";
+    private static final String CRITERIA = "An issue arose while grading this submission";
+
+    private Rubric.Results results;
 
     public GradingException() {
         super();
@@ -20,12 +26,12 @@ public class GradingException extends Exception{
 
     public GradingException(String message, String details) {
         super(message);
-        this.details = details;
+        setDetails(message, details);
     }
 
     public GradingException(String message, String details, Throwable cause) {
         super(message, cause);
-        this.details = details;
+        setDetails(message, details);
     }
 
     public GradingException(Throwable cause) {
@@ -34,14 +40,15 @@ public class GradingException extends Exception{
 
     public GradingException(String message, TestAnalysis analysis) {
         super(message);
-        this.analysis = analysis;
+        this.results = new Rubric.Results(message, 0f, 0, analysis, null);
     }
 
-    public String getDetails() {
-        return details;
+    public Rubric asRubric() {
+        return new Rubric(new EnumMap<>(Map.of(Rubric.RubricType.GRADING_ISSUE,
+                new Rubric.RubricItem(CATEGORY, results, CRITERIA))), false, getMessage());
     }
 
-    public TestAnalysis getAnalysis() {
-        return analysis;
+    private void setDetails(String message, String details) {
+        this.results = new Rubric.Results(message, 0f, 0, null, details);
     }
 }

--- a/src/main/java/edu/byu/cs/autograder/GradingException.java
+++ b/src/main/java/edu/byu/cs/autograder/GradingException.java
@@ -1,7 +1,6 @@
 package edu.byu.cs.autograder;
 
 import edu.byu.cs.model.Rubric;
-import edu.byu.cs.model.TestAnalysis;
 
 import java.util.EnumMap;
 import java.util.Map;
@@ -24,32 +23,18 @@ public class GradingException extends Exception{
         super(message, cause);
     }
 
-    public GradingException(String message, String details) {
-        super(message);
-        setDetails(message, details);
-    }
-
-    public GradingException(String message, String details, Throwable cause) {
-        super(message, cause);
-        setDetails(message, details);
-    }
-
     public GradingException(Throwable cause) {
         super(cause);
     }
 
-    public GradingException(String message, TestAnalysis analysis) {
+    public GradingException(String message, Rubric.Results results) {
         super(message);
-        this.results = new Rubric.Results(message, 0f, 0, analysis, null);
+        this.results = results;
     }
 
     public Rubric asRubric() {
         EnumMap<Rubric.RubricType, Rubric.RubricItem> items = (results == null) ? null :
                 new EnumMap<>(Map.of(Rubric.RubricType.GRADING_ISSUE, new Rubric.RubricItem(CATEGORY, results, CRITERIA)));
         return new Rubric(items, false, getMessage());
-    }
-
-    private void setDetails(String message, String details) {
-        this.results = new Rubric.Results(message, 0f, 0, null, details);
     }
 }

--- a/src/main/java/edu/byu/cs/autograder/GradingException.java
+++ b/src/main/java/edu/byu/cs/autograder/GradingException.java
@@ -44,8 +44,9 @@ public class GradingException extends Exception{
     }
 
     public Rubric asRubric() {
-        return new Rubric(new EnumMap<>(Map.of(Rubric.RubricType.GRADING_ISSUE,
-                new Rubric.RubricItem(CATEGORY, results, CRITERIA))), false, getMessage());
+        EnumMap<Rubric.RubricType, Rubric.RubricItem> items = (results == null) ? null :
+                new EnumMap<>(Map.of(Rubric.RubricType.GRADING_ISSUE, new Rubric.RubricItem(CATEGORY, results, CRITERIA)));
+        return new Rubric(items, false, getMessage());
     }
 
     private void setDetails(String message, String details) {

--- a/src/main/java/edu/byu/cs/autograder/GradingObserver.java
+++ b/src/main/java/edu/byu/cs/autograder/GradingObserver.java
@@ -10,9 +10,7 @@ public interface GradingObserver {
 
     void notifyError(String message);
 
-    void notifyError(String message, String details);
-
-    void notifyError(String message, TestAnalysis analysis);
+    void notifyError(String message, Submission submission);
 
     void notifyWarning(String message);
 

--- a/src/main/java/edu/byu/cs/autograder/compile/CompileHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/compile/CompileHelper.java
@@ -6,6 +6,7 @@ import edu.byu.cs.autograder.compile.modifiers.PassoffJarModifier;
 import edu.byu.cs.autograder.compile.modifiers.PomModifier;
 import edu.byu.cs.autograder.compile.modifiers.TestFactoryModifier;
 import edu.byu.cs.autograder.compile.verifers.*;
+import edu.byu.cs.model.Rubric;
 import edu.byu.cs.util.ProcessUtils;
 
 import java.io.IOException;
@@ -65,7 +66,8 @@ public class CompileHelper {
         try {
             ProcessUtils.ProcessOutput output = ProcessUtils.runProcess(processBuilder, 90000); //90 seconds
             if (output.statusCode() != 0) {
-                throw new GradingException("Failed to compile", getMavenError(output.stdOut()));
+                Rubric.Results results = Rubric.Results.textError("Your Java source code could not be compiled", getMavenError(output.stdOut()));
+                throw new GradingException("Failed to compile", results);
             }
         } catch (ProcessUtils.ProcessException ex) {
             throw new GradingException("Failed to compile: %s".formatted(ex.getMessage()), ex);

--- a/src/main/java/edu/byu/cs/autograder/compile/StudentCodeReader.java
+++ b/src/main/java/edu/byu/cs/autograder/compile/StudentCodeReader.java
@@ -21,8 +21,10 @@ public class StudentCodeReader {
         Set<File> files = new HashSet<>();
         for(String module: modules) {
             Path moduleRoot = Path.of(stageRepo.getPath(), module);
-            try (Stream<Path> paths = Files.walk(moduleRoot)) {
-                paths.filter(path -> path.toFile().isFile()).forEach((path -> files.add(path.toFile())));
+            if(moduleRoot.toFile().exists()) {
+                try (Stream<Path> paths = Files.walk(moduleRoot)) {
+                    paths.filter(path -> path.toFile().isFile()).forEach((path -> files.add(path.toFile())));
+                }
             }
         }
         return files;

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -171,8 +171,7 @@ public class GitHelper {
         return new CommitVerificationResult(
                 verified, true,
                 0, 0, 0, originalPenaltyPct, failureMessage,
-                null, null,
-                firstPassingSubmission.headHash(), null
+                null, null, headHash, null
         );
     }
 

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -97,7 +97,7 @@ public class GitHelper {
         } catch (GitAPIException e) {
             gradingContext.observer().notifyError("Failed to clone repo: " + e.getMessage());
             LOGGER.error("Failed to clone repo", e);
-            throw new GradingException("Failed to clone repo: ",  e.getMessage());
+            throw new GradingException("Failed to clone repo: " + e.getMessage());
         }
     }
 

--- a/src/main/java/edu/byu/cs/autograder/score/Scorer.java
+++ b/src/main/java/edu/byu/cs/autograder/score/Scorer.java
@@ -368,7 +368,7 @@ public class Scorer {
      * @param notes Any notes that are associated with the submission.
      *              More comments may be added to this string while preparing the Submission.
      */
-    private Submission generateSubmissionObject(Rubric rubric, CommitVerificationResult commitVerificationResult,
+    public Submission generateSubmissionObject(Rubric rubric, CommitVerificationResult commitVerificationResult,
                                                 int numDaysLate, float score, String notes)
             throws GradingException, DataAccessException {
         if (commitVerificationResult == null) {

--- a/src/main/java/edu/byu/cs/autograder/test/PreviousPhasePassoffTestGrader.java
+++ b/src/main/java/edu/byu/cs/autograder/test/PreviousPhasePassoffTestGrader.java
@@ -83,6 +83,6 @@ public class PreviousPhasePassoffTestGrader extends TestGrader{
 
     @Override
     protected Rubric.RubricType rubricType() {
-        return Rubric.RubricType.PREVIOUS_TESTS;
+        return Rubric.RubricType.GRADING_ISSUE;
     }
 }

--- a/src/main/java/edu/byu/cs/autograder/test/PreviousPhasePassoffTestGrader.java
+++ b/src/main/java/edu/byu/cs/autograder/test/PreviousPhasePassoffTestGrader.java
@@ -4,10 +4,7 @@ import edu.byu.cs.autograder.GradingContext;
 import edu.byu.cs.autograder.GradingException;
 import edu.byu.cs.dataAccess.DaoService;
 import edu.byu.cs.dataAccess.DataAccessException;
-import edu.byu.cs.model.Phase;
-import edu.byu.cs.model.Rubric;
-import edu.byu.cs.model.RubricConfig;
-import edu.byu.cs.model.TestAnalysis;
+import edu.byu.cs.model.*;
 import edu.byu.cs.util.PhaseUtils;
 
 import java.io.File;
@@ -16,7 +13,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class PreviousPhasePassoffTestGrader extends TestGrader{
-    private static final String ERROR_MESSAGE = "Failed previous tests. Cannot pass off until previous tests pass";
+    private static final String ERROR_MESSAGE = "Failed previous phases' tests. Cannot pass off until previous tests pass.";
 
     public PreviousPhasePassoffTestGrader(GradingContext gradingContext) {
         super(gradingContext);
@@ -72,8 +69,19 @@ public class PreviousPhasePassoffTestGrader extends TestGrader{
     protected float getScore(TestAnalysis testResults) throws GradingException {
         if (testResults.root().getNumTestsFailed() == 0) return 1f;
         testResults = new TestAnalysis(testResults.root(), null, testResults.error());
-        Rubric.Results results = Rubric.Results.testError(ERROR_MESSAGE, testResults);
+        StringBuilder errorBuilder = new StringBuilder(ERROR_MESSAGE).append(" \nFailing tests: \n");
+        failingTests(testResults.root(), errorBuilder);
+        Rubric.Results results = Rubric.Results.testError(errorBuilder.toString(), testResults);
         throw new GradingException("Failed previous phase tests", results);
+    }
+
+    private void failingTests(TestNode node, StringBuilder builder) {
+        if(node.getPassed() != null && !node.getPassed()) {
+            builder.append(node.getTestName()).append(" \n");
+        }
+        for(TestNode child : node.getChildren().values()) {
+            failingTests(child, builder);
+        }
     }
 
     @Override

--- a/src/main/java/edu/byu/cs/autograder/test/PreviousPhasePassoffTestGrader.java
+++ b/src/main/java/edu/byu/cs/autograder/test/PreviousPhasePassoffTestGrader.java
@@ -72,7 +72,8 @@ public class PreviousPhasePassoffTestGrader extends TestGrader{
     protected float getScore(TestAnalysis testResults) throws GradingException {
         if (testResults.root().getNumTestsFailed() == 0) return 1f;
         testResults = new TestAnalysis(testResults.root(), null, testResults.error());
-        throw new GradingException(ERROR_MESSAGE, testResults);
+        Rubric.Results results = Rubric.Results.testError(ERROR_MESSAGE, testResults);
+        throw new GradingException("Failed previous phase tests", results);
     }
 
     @Override

--- a/src/main/java/edu/byu/cs/autograder/test/TestHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/test/TestHelper.java
@@ -1,6 +1,7 @@
 package edu.byu.cs.autograder.test;
 
 import edu.byu.cs.autograder.GradingException;
+import edu.byu.cs.model.Rubric;
 import edu.byu.cs.model.TestAnalysis;
 import edu.byu.cs.util.FileUtils;
 import edu.byu.cs.util.ProcessUtils;
@@ -84,7 +85,8 @@ public class TestHelper {
 
                 if (compileOutput.statusCode() != 0) {
                     LOGGER.error("Error compiling tests: {}", compileOutput.stdErr());
-                    throw new GradingException("Error compiling tests:", compileOutput.stdErr());
+                    Rubric.Results results = Rubric.Results.textError("Error compiling tests", compileOutput.stdErr());
+                    throw new GradingException(results.notes(), results);
                 }
             }
         } catch (IOException | ProcessUtils.ProcessException e) {

--- a/src/main/java/edu/byu/cs/controller/SubmissionController.java
+++ b/src/main/java/edu/byu/cs/controller/SubmissionController.java
@@ -359,13 +359,8 @@ public class SubmissionController {
             }
 
             @Override
-            public void notifyError(String message, String details) {
-                notifyError(message, Map.of("details", details));
-            }
-
-            @Override
-            public void notifyError(String message, TestAnalysis analysis) {
-                notifyError(message, Map.of("analysis", analysis));
+            public void notifyError(String message, Submission submission) {
+                notifyError(message, Map.of("results", Serializer.serialize(submission)));
             }
 
             public void notifyError(String message, Map<String, Object> contents) {

--- a/src/main/java/edu/byu/cs/model/Rubric.java
+++ b/src/main/java/edu/byu/cs/model/Rubric.java
@@ -58,7 +58,15 @@ public record Rubric(
             Integer possiblePoints,
             TestAnalysis testResults,
             String textResults
-    ) { }
+    ) {
+        public static Results testError(String notes, TestAnalysis testResults) {
+            return new Results(notes, 0f, 0, testResults, null);
+        }
+
+        public static Results textError(String notes, String textResults) {
+            return new Results(notes, 0f, 0, null, textResults);
+        }
+    }
 
     public enum RubricType {
         PASSOFF_TESTS,

--- a/src/main/java/edu/byu/cs/model/Rubric.java
+++ b/src/main/java/edu/byu/cs/model/Rubric.java
@@ -65,6 +65,6 @@ public record Rubric(
         UNIT_TESTS,
         QUALITY,
         GIT_COMMITS,
-        PREVIOUS_TESTS
+        GRADING_ISSUE
     }
 }

--- a/src/main/resources/frontend/src/components/MoreInfo.vue
+++ b/src/main/resources/frontend/src/components/MoreInfo.vue
@@ -34,6 +34,7 @@ defineProps<{
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-top: 4px;
 }
 #slotInfo {
   display: flex;

--- a/src/main/resources/frontend/src/views/StudentView/LiveStatus.vue
+++ b/src/main/resources/frontend/src/views/StudentView/LiveStatus.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 
 import {onMounted, ref} from "vue";
-import type {Submission, TestResult} from "@/types/types";
+import type {Submission} from "@/types/types";
 import {subscribeToGradingUpdates} from "@/stores/submissions";
-import PopUp from "@/components/PopUp.vue";
-import RubricItemResultsView from "@/views/StudentView/RubricItemResultsView.vue";
 
 const emit = defineEmits<{
   "show-results": [submission: Submission];
@@ -16,9 +14,6 @@ type GradingStatus = {
 }
 
 const statuses = ref<GradingStatus[]>([]);
-const errorDetails = ref<string>("");
-const errorTestResults = ref<TestResult | undefined>(undefined);
-const displayError = ref<boolean>(false);
 const warnings = ref<boolean>(false);
 const submission = ref<Submission | undefined>(undefined);
 
@@ -48,8 +43,9 @@ onMounted(() => {
         return;
       case 'error':
         statuses.value.push({type: 'error', status: `Error: ${messageData.message}`});
-        errorDetails.value = messageData.details;
-        errorTestResults.value = messageData.analysis;
+        warnings.value = true;
+        const errorResults = JSON.parse(messageData.results);
+        submission.value = errorResults;
         return;
     }
   });
@@ -76,16 +72,6 @@ const getStatusClass = (status: GradingStatus) => {
 <div class="status-container">
   <span v-for="status of statuses" :class=getStatusClass(status)>{{ status.status }}</span>
   <button v-if="warnings && submission" @click="() => {showResults(submission!)}">See Results</button>
-  <div v-if="errorDetails || errorTestResults"
-       class="selectable">
-    <button @click="() => {displayError = true;}">Click here</button>
-  </div>
-  <PopUp
-      v-if="displayError"
-      @closePopUp="() => {displayError = false}">
-    <p v-if="errorDetails" style="white-space: pre">{{errorDetails}}</p>
-    <RubricItemResultsView v-if="errorTestResults" :test-results="errorTestResults" />
-  </PopUp>
 </div>
 </template>
 

--- a/src/main/resources/frontend/src/views/StudentView/SubmissionInfo.vue
+++ b/src/main/resources/frontend/src/views/StudentView/SubmissionInfo.vue
@@ -49,7 +49,7 @@ const approve = async (penalize: boolean, emit: (event: string, ...args: any[]) 
       <span v-else>passed <i class="fa-solid fa-circle-check" style="color: green"/></span>
     </p>
 
-    <div v-if="useAuthStore().user?.role == 'ADMIN' && commitVerificationFailed(submission)">
+    <div v-if="useAuthStore().user?.role == 'ADMIN' && submission.passed && commitVerificationFailed(submission)">
       <InfoPanel id="approveSubmission">
         <h4>Approve Blocked Submission</h4>
         <p>This submission was blocked because it did not meet the git commit requirements.</p>


### PR DESCRIPTION
This adds functionality to record instances of grading issues (compilation issues, previous tests failing) in the submission table so that the students can see that output after closing the tab and the TA's can see that information.
This also fixes a couple of bugs/oversights that were either bothering me or I found while creating this.

@Fiwafoofa I'm not entirely certain of some of the wording. Could you test it out and see if you have any better ideas for some of the messages?