### PR TITLE
391 autograding for the GitHub assignment

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/Grader.java
+++ b/src/main/java/edu/byu/cs/autograder/Grader.java
@@ -123,7 +123,7 @@ public class Grader implements Runnable {
                     case PASSOFF_TESTS -> new PassoffTestGrader(gradingContext).runTests();
                     case UNIT_TESTS -> new UnitTestGrader(gradingContext).runTests();
                     case QUALITY -> new QualityGrader(gradingContext).runQualityChecks();
-                    case GITHUB_REPO -> new GitHubAssignmentGrader().runTests();
+                    case GITHUB_REPO -> new GitHubAssignmentGrader().grade();
                     case GIT_COMMITS, GRADING_ISSUE -> null;
                 };
                 if (results != null) {

--- a/src/main/java/edu/byu/cs/autograder/Grader.java
+++ b/src/main/java/edu/byu/cs/autograder/Grader.java
@@ -93,7 +93,7 @@ public class Grader implements Runnable {
             }
 
             RubricConfig rubricConfig = DaoService.getRubricConfigDao().getRubricConfig(gradingContext.phase());
-            Rubric rubric = evaluateProject(RUN_COMPILATION ? rubricConfig : null);
+            Rubric rubric = evaluateProject(RUN_COMPILATION ? rubricConfig : null, commitVerificationResult);
 
             Submission submission = new Scorer(gradingContext).score(rubric, commitVerificationResult);
             DaoService.getSubmissionDao().insertSubmission(submission);
@@ -110,7 +110,7 @@ public class Grader implements Runnable {
         }
     }
 
-    private Rubric evaluateProject(RubricConfig rubricConfig) throws GradingException, DataAccessException {
+    private Rubric evaluateProject(RubricConfig rubricConfig, CommitVerificationResult commitVerificationResult) throws GradingException, DataAccessException {
         EnumMap<Rubric.RubricType, Rubric.RubricItem> rubricItems = new EnumMap<>(Rubric.RubricType.class);
         if (rubricConfig == null) {
             return new Rubric(new EnumMap<>(Rubric.RubricType.class), false, "No Rubric Config");
@@ -123,7 +123,7 @@ public class Grader implements Runnable {
                     case PASSOFF_TESTS -> new PassoffTestGrader(gradingContext).runTests();
                     case UNIT_TESTS -> new UnitTestGrader(gradingContext).runTests();
                     case QUALITY -> new QualityGrader(gradingContext).runQualityChecks();
-                    case GITHUB_REPO -> new GitHubAssignmentGrader().grade();
+                    case GITHUB_REPO -> new GitHubAssignmentGrader().grade(commitVerificationResult);
                     case GIT_COMMITS, GRADING_ISSUE -> null;
                 };
                 if (results != null) {

--- a/src/main/java/edu/byu/cs/autograder/Grader.java
+++ b/src/main/java/edu/byu/cs/autograder/Grader.java
@@ -7,7 +7,7 @@ import edu.byu.cs.autograder.git.CommitVerificationResult;
 import edu.byu.cs.autograder.git.GitHelper;
 import edu.byu.cs.autograder.quality.QualityGrader;
 import edu.byu.cs.autograder.score.Scorer;
-import edu.byu.cs.autograder.test.GitHubAssignmentGrader;
+import edu.byu.cs.autograder.git.GitHubAssignmentGrader;
 import edu.byu.cs.autograder.test.PassoffTestGrader;
 import edu.byu.cs.autograder.test.PreviousPhasePassoffTestGrader;
 import edu.byu.cs.autograder.test.UnitTestGrader;

--- a/src/main/java/edu/byu/cs/autograder/Grader.java
+++ b/src/main/java/edu/byu/cs/autograder/Grader.java
@@ -7,6 +7,7 @@ import edu.byu.cs.autograder.git.CommitVerificationResult;
 import edu.byu.cs.autograder.git.GitHelper;
 import edu.byu.cs.autograder.quality.QualityGrader;
 import edu.byu.cs.autograder.score.Scorer;
+import edu.byu.cs.autograder.test.GitHubAssignmentGrader;
 import edu.byu.cs.autograder.test.PassoffTestGrader;
 import edu.byu.cs.autograder.test.PreviousPhasePassoffTestGrader;
 import edu.byu.cs.autograder.test.UnitTestGrader;
@@ -85,7 +86,7 @@ public class Grader implements Runnable {
             Thread.sleep(1000);
             CommitVerificationResult commitVerificationResult = gitHelper.setUpAndVerifyHistory();
             dbHelper.setUp();
-            if (RUN_COMPILATION) {
+            if (RUN_COMPILATION && gradingContext.phase() != Phase.GitHub) {
                 compileHelper.compile();
                 new PreviousPhasePassoffTestGrader(gradingContext).runTests();
             }
@@ -128,6 +129,7 @@ public class Grader implements Runnable {
                     case PASSOFF_TESTS -> new PassoffTestGrader(gradingContext).runTests();
                     case UNIT_TESTS -> new UnitTestGrader(gradingContext).runTests();
                     case QUALITY -> new QualityGrader(gradingContext).runQualityChecks();
+                    case GITHUB_REPO -> new GitHubAssignmentGrader().runTests();
                     case GIT_COMMITS, PREVIOUS_TESTS -> null;
                 };
                 if (results != null) {

--- a/src/main/java/edu/byu/cs/autograder/compile/verifers/ModifiedTestFilesVerifier.java
+++ b/src/main/java/edu/byu/cs/autograder/compile/verifers/ModifiedTestFilesVerifier.java
@@ -64,11 +64,11 @@ public class ModifiedTestFilesVerifier implements StudentCodeVerifier {
                     """
                     Warning: your test files have changed. This could lead to the autograder giving
                     different results than your local machine.
-                    Modified Files: %s.
-                    Missing Files: %s.
+                    %s
+                    %s
                     """,
-                    modifiedFiles.isEmpty() ? "None" : String.join(", ", modifiedFiles),
-                    missingFiles.isEmpty() ? "None" : String.join(", ", missingFiles)
+                    !modifiedFiles.isEmpty() ? "Modified Files: " + String.join(", ", modifiedFiles) : "",
+                    !missingFiles.isEmpty() ? "Missing Files: " + String.join(", ", missingFiles) : ""
             );
             context.observer().notifyWarning(warningMessage);
             modifiedFiles.clear();

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -350,14 +350,14 @@ public class GitHelper {
         return currentThreshold;
     }
 
-    private static ArrayList<String> evaluateConditions(CV[] assertedConditions, int commitVerificationPenaltyPct) {
+    private ArrayList<String> evaluateConditions(CV[] assertedConditions, int commitVerificationPenaltyPct) {
         ArrayList<String> errorMessages = new ArrayList<>();
         for (CV assertedCondition : assertedConditions) {
             if (!assertedCondition.fails) continue;
             errorMessages.add(assertedCondition.errorMsg());
         }
 
-        if (!errorMessages.isEmpty()) {
+        if (!errorMessages.isEmpty() && PhaseUtils.requiresTAPassoffForCommits(gradingContext.phase())) {
             errorMessages.add("Since you did not meet the prerequisites for commit frequency, "
                     + "you will need to talk to a TA to receive a score. ");
             errorMessages.add(String.format("It may come with a %d%% penalty.", commitVerificationPenaltyPct));

--- a/src/main/java/edu/byu/cs/autograder/git/GitHubAssignmentGrader.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHubAssignmentGrader.java
@@ -1,4 +1,4 @@
-package edu.byu.cs.autograder.test;
+package edu.byu.cs.autograder.git;
 
 import edu.byu.cs.dataAccess.DaoService;
 import edu.byu.cs.dataAccess.DataAccessException;

--- a/src/main/java/edu/byu/cs/autograder/git/GitHubAssignmentGrader.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHubAssignmentGrader.java
@@ -12,7 +12,7 @@ import edu.byu.cs.model.RubricConfig;
  */
 public class GitHubAssignmentGrader {
 
-    public Rubric.Results runTests() throws DataAccessException {
+    public Rubric.Results grade() throws DataAccessException {
         RubricConfig rubricConfig =
                 DaoService.getRubricConfigDao().getRubricConfig(Phase.GitHub);
         RubricConfig.RubricConfigItem configItem =

--- a/src/main/java/edu/byu/cs/autograder/git/GitHubAssignmentGrader.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHubAssignmentGrader.java
@@ -12,22 +12,20 @@ import edu.byu.cs.model.RubricConfig;
  */
 public class GitHubAssignmentGrader {
 
-    public Rubric.Results grade() throws DataAccessException {
+    public Rubric.Results grade(CommitVerificationResult commitVerificationResult) throws DataAccessException {
         RubricConfig rubricConfig =
                 DaoService.getRubricConfigDao().getRubricConfig(Phase.GitHub);
         RubricConfig.RubricConfigItem configItem =
                 rubricConfig.items().get(Rubric.RubricType.GITHUB_REPO);
 
-        return new Rubric.Results(
-                "Successfully fetched your repository. If you passed the required commit count, " +
-                        "your grade should have been updated in Canvas. You should see this comment " +
-                        "in Canvas as well.",
-                1f,
-                configItem.points(),
-                null,
-                "If you have any errors in your code or code quality, " +
-                        "you will see the details here."
-        );
+        if(commitVerificationResult.verified()) {
+            return new Rubric.Results("Successfully fetched your repository and verified commits",
+                    1f, configItem.points(), null, null);
+        }
+        else {
+            return new Rubric.Results("Successfully fetched your repository, but the number of commits is insufficient",
+                    0f, configItem.points(), null, commitVerificationResult.failureMessage());
+        }
     }
 
 }

--- a/src/main/java/edu/byu/cs/autograder/score/Scorer.java
+++ b/src/main/java/edu/byu/cs/autograder/score/Scorer.java
@@ -167,7 +167,10 @@ public class Scorer {
 
         CanvasRubricAssessment existingAssessment = getExistingAssessment(canvasUserId, assignmentNum);
         CanvasRubricAssessment newAssessment = addExistingPoints(constructCanvasRubricAssessment(rubric), existingAssessment);
-        setCommitVerificationPenalty(newAssessment, gradingContext, commitVerificationResult);
+
+        if (PhaseUtils.phaseHasCommitPenalty(gradingContext.phase())) {
+            setCommitVerificationPenalty(newAssessment, gradingContext, commitVerificationResult);
+        }
 
         // prevent score from being saved to canvas if it will lower their score
         String notes = "";

--- a/src/main/java/edu/byu/cs/autograder/test/GitHubAssignmentGrader.java
+++ b/src/main/java/edu/byu/cs/autograder/test/GitHubAssignmentGrader.java
@@ -1,0 +1,33 @@
+package edu.byu.cs.autograder.test;
+
+import edu.byu.cs.dataAccess.DaoService;
+import edu.byu.cs.dataAccess.DataAccessException;
+import edu.byu.cs.model.Phase;
+import edu.byu.cs.model.Rubric;
+import edu.byu.cs.model.RubricConfig;
+
+/**
+ * Grades the GitHub assignment. If a student passes the commit verification,
+ * then this grader will give them full points.
+ */
+public class GitHubAssignmentGrader {
+
+    public Rubric.Results runTests() throws DataAccessException {
+        RubricConfig rubricConfig =
+                DaoService.getRubricConfigDao().getRubricConfig(Phase.GitHub);
+        RubricConfig.RubricConfigItem configItem =
+                rubricConfig.items().get(Rubric.RubricType.GITHUB_REPO);
+
+        return new Rubric.Results(
+                "Successfully fetched your repository. If you passed the required commit count, " +
+                        "your grade should have been updated in Canvas. You should see this comment " +
+                        "in Canvas as well.",
+                1f,
+                configItem.points(),
+                null,
+                "If you have any errors in your code or code quality, " +
+                        "you will see the details here."
+        );
+    }
+
+}

--- a/src/main/java/edu/byu/cs/canvas/CanvasIntegrationImpl.java
+++ b/src/main/java/edu/byu/cs/canvas/CanvasIntegrationImpl.java
@@ -5,8 +5,10 @@ import edu.byu.cs.canvas.model.CanvasRubricItem;
 import edu.byu.cs.canvas.model.CanvasSection;
 import edu.byu.cs.canvas.model.CanvasSubmission;
 import edu.byu.cs.controller.SubmissionController;
+import edu.byu.cs.model.Phase;
 import edu.byu.cs.model.User;
 import edu.byu.cs.properties.ApplicationProperties;
+import edu.byu.cs.util.PhaseUtils;
 import edu.byu.cs.util.Serializer;
 import org.eclipse.jgit.annotations.Nullable;
 
@@ -30,8 +32,7 @@ public class CanvasIntegrationImpl implements CanvasIntegration {
     // FIXME: set this dynamically or pull from config
     private static final int COURSE_NUMBER = 26822;
 
-    // FIXME: set this dynamically or pull from config
-    private static final int GIT_REPO_ASSIGNMENT_NUMBER = 941080;
+    private static final int GIT_REPO_ASSIGNMENT_NUMBER = PhaseUtils.getPhaseAssignmentNumber(Phase.GitHub);
 
     private record Enrollment(EnrollmentType type) {
 

--- a/src/main/java/edu/byu/cs/model/Phase.java
+++ b/src/main/java/edu/byu/cs/model/Phase.java
@@ -23,5 +23,6 @@ public enum Phase {
      * Would be named <code>GitCommits</code>, but the SQL table
      * requires the phase to be no more than 9 chars.
      */
-    Commits
+    Commits,
+    GitHub
 }

--- a/src/main/java/edu/byu/cs/model/Rubric.java
+++ b/src/main/java/edu/byu/cs/model/Rubric.java
@@ -65,6 +65,7 @@ public record Rubric(
         UNIT_TESTS,
         QUALITY,
         GIT_COMMITS,
-        PREVIOUS_TESTS
+        PREVIOUS_TESTS,
+        GITHUB_REPO
     }
 }

--- a/src/main/resources/frontend/src/stores/uiConfig.ts
+++ b/src/main/resources/frontend/src/stores/uiConfig.ts
@@ -16,6 +16,8 @@ const getPhaseName = (phase: Phase | null) => {
       return "Phase 6: Gameplay"
     case Phase.Quality:
       return "Code Quality Check"
+    case Phase.GitHub:
+      return "Chess GitHub Repository";
     default:
       return "Chess Project"
   }
@@ -37,6 +39,8 @@ const getSpecLink = (phase: Phase | null) => {
       return "https://github.com/softwareconstruction240/softwareconstruction/blob/main/chess/6-gameplay/gameplay.md"
     case Phase.Quality:
       return "https://github.com/softwareconstruction240/softwareconstruction/blob/main/chess/code-quality-rubric.md"
+    case Phase.GitHub:
+      return "https://github.com/softwareconstruction240/softwareconstruction/blob/main/chess/chess-github-repository/chess-github-repository.md"
     default:
       return "https://github.com/softwareconstruction240/softwareconstruction/blob/main/chess/chess.md#readme"
   }

--- a/src/main/resources/frontend/src/types/types.ts
+++ b/src/main/resources/frontend/src/types/types.ts
@@ -5,7 +5,8 @@ export enum Phase {
     Phase4,
     Phase5,
     Phase6,
-    Quality
+    Quality,
+    GitHub
 }
 
 export type TestNode = {

--- a/src/main/resources/frontend/src/utils/utils.ts
+++ b/src/main/resources/frontend/src/utils/utils.ts
@@ -104,8 +104,9 @@ export const generateResultsHtmlStringFromTestNode = (node: TestNode, indent: st
   return result;
 }
 
-export const phaseString = (phase: Phase | "Quality") => {
+export const phaseString = (phase: Phase | "Quality" | "GitHub") => {
   if (phase == 'Quality') { return "Code Quality Check"; }
+  if (phase == "GitHub") { return "Chess GitHub Repository"; }
   else { return "Phase " + phase.toString().charAt(5)}
 }
 
@@ -115,4 +116,12 @@ export const sortedItems = (items: Record<RubricType, RubricItem>): RubricItem[]
     const bPoints = items[b as RubricType].results.possiblePoints;
     return bPoints - aPoints;
   }).map((item) => items[item as RubricType]);
+}
+
+export const phaseRequiresTAPassoffForCommits = (phase: Phase | "Quality" | "GitHub"): boolean => {
+  // FIXME: There's some funky type stuff going on here. Whenever I find `typeof phase` is prints out `string`
+  // however, when actually calling this function, it requires `Phase` as a parameter type by the
+  // TS transpiler. Similar case like in the `phaseString` function above.
+  return !(phase === "Quality" || phase === "GitHub");
+
 }

--- a/src/main/resources/frontend/src/views/AdminView/SubmissionsView.vue
+++ b/src/main/resources/frontend/src/views/AdminView/SubmissionsView.vue
@@ -122,6 +122,7 @@ const adminSubmit = async () => {
         <option :value=Phase.Phase5>Phase 5</option>
         <option :value=Phase.Phase6>Phase 6</option>
         <option :value=Phase.Quality>Code Quality Check</option>
+        <option :value=Phase.GitHub>Github Assignment</option>
       </select>
       <button
         :disabled="(selectedAdminPhase === null)

--- a/src/main/resources/frontend/src/views/AdminView/SubmissionsView.vue
+++ b/src/main/resources/frontend/src/views/AdminView/SubmissionsView.vue
@@ -115,6 +115,7 @@ const adminSubmit = async () => {
     <div id="submitDialog">
       <select v-model="selectedAdminPhase">
         <option :value=null selected disabled>Select a phase</option>
+        <option :value=Phase.GitHub>GitHub Repository</option>
         <option :value=Phase.Phase0>Phase 0</option>
         <option :value=Phase.Phase1>Phase 1</option>
         <option :value=Phase.Phase3>Phase 3</option>
@@ -122,7 +123,6 @@ const adminSubmit = async () => {
         <option :value=Phase.Phase5>Phase 5</option>
         <option :value=Phase.Phase6>Phase 6</option>
         <option :value=Phase.Quality>Code Quality Check</option>
-        <option :value=Phase.GitHub>Github Assignment</option>
       </select>
       <button
         :disabled="(selectedAdminPhase === null)

--- a/src/main/resources/frontend/src/views/HomeView.vue
+++ b/src/main/resources/frontend/src/views/HomeView.vue
@@ -67,6 +67,7 @@ const handleGradingDone = async () => {
       <div id="submitDialog">
         <select v-model="selectedPhase" @change="useSubmissionStore().checkGrading()">
           <option :value=null selected disabled>Select a phase</option>
+          <option :value=Phase.GitHub>GitHub Repository</option>
           <option :value=Phase.Phase0>Phase 0</option>
           <option :value=Phase.Phase1>Phase 1</option>
           <option :value=Phase.Phase3>Phase 3</option>
@@ -74,7 +75,6 @@ const handleGradingDone = async () => {
           <option :value=Phase.Phase5>Phase 5</option>
           <option :value=Phase.Phase6>Phase 6</option>
           <option :value=Phase.Quality>Code Quality Check</option>
-          <option :value=Phase.GitHub>GitHub Repository</option>
         </select>
         <button :disabled="(selectedPhase === null) || useSubmissionStore().currentlyGrading" class="primary" @click="submitSelectedPhase">Submit</button>
       </div>

--- a/src/main/resources/frontend/src/views/HomeView.vue
+++ b/src/main/resources/frontend/src/views/HomeView.vue
@@ -74,6 +74,7 @@ const handleGradingDone = async () => {
           <option :value=Phase.Phase5>Phase 5</option>
           <option :value=Phase.Phase6>Phase 6</option>
           <option :value=Phase.Quality>Code Quality Check</option>
+          <option :value=Phase.GitHub>GitHub Repository</option>
         </select>
         <button :disabled="(selectedPhase === null) || useSubmissionStore().currentlyGrading" class="primary" @click="submitSelectedPhase">Submit</button>
       </div>

--- a/src/main/resources/frontend/src/views/StudentView/ResultsPreview.vue
+++ b/src/main/resources/frontend/src/views/StudentView/ResultsPreview.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import type { Submission } from '@/types/types'
-import {scoreToPercentage, roundTwoDecimals, commitVerificationFailed, sortedItems} from '@/utils/utils'
+import {scoreToPercentage,
+  roundTwoDecimals,
+  commitVerificationFailed,
+  sortedItems,
+  phaseRequiresTAPassoffForCommits
+} from '@/utils/utils'
 import PopUp from '@/components/PopUp.vue'
 import SubmissionInfo from '@/views/StudentView/SubmissionInfo.vue'
 import { ref } from 'vue'
@@ -22,8 +27,12 @@ const openDetails = ref<boolean>(false);
       </div>
 
       <div v-else-if="commitVerificationFailed(submission)"> <!-- IF SUBMISSION IS BLOCKED -->
-        <h2><i class="fa-solid fa-triangle-exclamation" style="color: red"/> Submission blocked! <i class="fa-solid fa-triangle-exclamation" style="color: red"/></h2>
-        <h3>You can not receive points on this phase until you talk to a TA</h3>
+        <h2>
+          <i class="fa-solid fa-triangle-exclamation" style="color: red"/> Submission blocked! <i class="fa-solid fa-triangle-exclamation" style="color: red"/>
+        </h2>
+        <h3 v-if="phaseRequiresTAPassoffForCommits(submission.phase)">
+          You can not receive points on this phase until you talk to a TA
+        </h3>
       </div>
 
       <div v-else>

--- a/src/main/resources/frontend/src/views/StudentView/RubricItemView.vue
+++ b/src/main/resources/frontend/src/views/StudentView/RubricItemView.vue
@@ -28,7 +28,7 @@ defineProps<{
         <p v-html="sanitizeHtml(rubricItem.results.notes)"/>
       </div>
 
-      <MoreInfo text="details">
+      <MoreInfo v-if="rubricItem.results.testResults || rubricItem.results.textResults" text="details">
         <div>
           <span class="category" v-html="rubricItem.category + ' '"/>
           <span class="score" v-html="Math.round(rubricItem.results.score) + '/' + rubricItem.results.possiblePoints + '<br/>'"/>

--- a/src/main/resources/frontend/src/views/StudentView/SubmissionInfo.vue
+++ b/src/main/resources/frontend/src/views/StudentView/SubmissionInfo.vue
@@ -56,7 +56,7 @@ const approve = async (penalize: boolean, emit: (event: string, ...args: any[]) 
       <span v-else>Passed <i class="fa-solid fa-circle-check" style="color: green"/></span>
     </p>
 
-    <div v-if="useAuthStore().user?.role == 'ADMIN' && submission.passed && commitVerificationFailed(submission)">
+    <div v-if="useAuthStore().user?.role == 'ADMIN' && submission.passed && commitVerificationFailed(submission) && phaseRequiresTAPassoffForCommits(submission.phase)">
       <InfoPanel id="approveSubmission">
         <h4>Approve Blocked Submission</h4>
         <p>This submission was blocked because it did not meet the git commit requirements.</p>

--- a/src/main/resources/frontend/src/views/StudentView/SubmissionInfo.vue
+++ b/src/main/resources/frontend/src/views/StudentView/SubmissionInfo.vue
@@ -6,7 +6,9 @@ import {
   commitVerificationFailed,
   generateClickableCommitLink,
   generateClickableLink,
-  nameOnSubmission, phaseString,
+  nameOnSubmission,
+  phaseRequiresTAPassoffForCommits,
+  phaseString,
   readableTimestamp,
   scoreToPercentage, sortedItems
 } from '@/utils/utils'
@@ -42,11 +44,16 @@ const approve = async (penalize: boolean, emit: (event: string, ...args: any[]) 
     <h3>{{nameOnSubmission(submission)}} ({{submission.netId}})</h3>
     <p>{{readableTimestamp(submission.timestamp)}}</p>
     <p v-html="generateClickableLink(submission.repoUrl)"/>
-    <p>commit: <span v-html="generateClickableCommitLink(submission.repoUrl, submission.headHash)"/></p>
-    <p>status:
+    <p>Commit: <span v-html="generateClickableCommitLink(submission.repoUrl, submission.headHash)"/></p>
+    <p>Status:
       <span v-if="!submission.passed">failed <i class="fa-solid fa-circle-xmark" style="color: red"/></span>
-      <span v-else-if="commitVerificationFailed(submission)"><i class="fa-solid fa-triangle-exclamation" style="color: red"/> <b>needs approval, go see a TA</b> <i class="fa-solid fa-triangle-exclamation" style="color: red"/></span>
-      <span v-else>passed <i class="fa-solid fa-circle-check" style="color: green"/></span>
+      <span v-else-if="commitVerificationFailed(submission)">
+        <i class="fa-solid fa-triangle-exclamation" style="color: red"/>
+        <b> commit verification failed! </b>
+        <b v-if="phaseRequiresTAPassoffForCommits(submission.phase)">Needs TA approval. Go see a TA </b>
+        <i class="fa-solid fa-triangle-exclamation" style="color: red"/>
+      </span>
+      <span v-else>Passed <i class="fa-solid fa-circle-check" style="color: green"/></span>
     </p>
 
     <div v-if="useAuthStore().user?.role == 'ADMIN' && commitVerificationFailed(submission)">

--- a/src/test/java/edu/byu/cs/autograder/git/GitHelperUtils.java
+++ b/src/test/java/edu/byu/cs/autograder/git/GitHelperUtils.java
@@ -3,6 +3,7 @@ package edu.byu.cs.autograder.git;
 import edu.byu.cs.analytics.CommitThreshold;
 import edu.byu.cs.autograder.GradingContext;
 import edu.byu.cs.autograder.GradingObserver;
+import edu.byu.cs.model.Phase;
 import edu.byu.cs.util.FileUtils;
 import org.eclipse.jgit.annotations.Nullable;
 import org.eclipse.jgit.api.Git;
@@ -229,7 +230,7 @@ public class GitHelperUtils {
         GradingObserver mockObserver = Mockito.mock(GradingObserver.class);
         var cvConfig = new CommitVerificationConfig(requiredCommits, requiredDaysWithCommits, minimumLinesChangedPerCommit, commitVerificationPenaltyPct, forgivenessMinutes);
         return new GradingContext(
-                null, null, null, null, null, null,
+                null, Phase.Phase0, null, null, null, null,
                 cvConfig, mockObserver, false);
     }
 


### PR DESCRIPTION
Resolves: https://github.com/softwareconstruction240/autograder/issues/391 

Added backend and frontend support for the autograding for the GitHub assignment. Essentially, student's have to submit their URL to canvas and submit on the autograder to have their assignment autograded. The autograder verifies that the GitHub repo is clonable and there was at least two commits: one for the initialization of the repository and the adding of `notes.md` and if so, grades the assignment based on late penalty (commit penalty is ignored). If not, then their submission is blocked.

Testing was done with these four repos:
* https://github.com/Fiwafoofa/chessWithoutCommit
* https://github.com/Fiwafoofa/chessWithCommit
* https://github.com/Fiwafoofa/chessTA
* https://github.com/19mdavenport/Spring2024Chess

A new rubric config item was added with the following SQL:
```sql
INSERT INTO autograder.rubric_config (phase, type, category, criteria, points)
VALUES ('GitHub', 'GITHUB_REPO', 'GitHub Repository', 'Two Git commits: one for creating the repository and another for `notes.md`.', 15);
```
(I couldn't find if or where the autograder populated the rubric_config automatically on runtime, so I DID NOT put any code that does that if relevant.)

And a new rubric for the GitHub assignment was added:
![Screenshot 2024-06-26 103339](https://github.com/softwareconstruction240/autograder/assets/126795096/acce4958-910c-41b4-891f-f5ae796176f6)

Also, in order to prevent the messages detailing when students had to talk to TA for failing commit requirements in the GitHub assignment, I had to make a slightly funky modification with the `GitHelperUtils`  where the grading context now uses Phase0 instead of `null` to prevent an exception occurring in `GitHelper`.

Also, I modified the message in `ModifiedTestFilesVerifier` because it was slightly annoying me :P