### PR TITLE
fix late penalty scores

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/score/Scorer.java
+++ b/src/main/java/edu/byu/cs/autograder/score/Scorer.java
@@ -98,7 +98,8 @@ public class Scorer {
      * <br>
      * Calling this method constitutes a successful, verified submission that will be submitted to canvas.
      *
-     * @param rubric                   Required.
+     * @param rubric                   The original rubric for saving to the database and display to users
+     * @param lateAppliedRubric        Rubric with late penalties applied for sending to canvas
      * @param commitVerificationResult Required when originally creating a submission.
      *                                 Can be null when sending scores to Canvas; this will disable
      *                                 any automatic point deductions for verification, and also result in


### PR DESCRIPTION
Fixed by changing the `applyLatePenalty` method to return a new Rubric rather than alter an existing rubric, then determining score and sending to canvas with the rubric with the penalty applied but generating the submission object with the rubric without the penalty.


Like I said in the issue, can be confusing: 
![image](https://github.com/user-attachments/assets/2483253f-7771-4067-9ce7-1c720f74599f) (auto-grader rubric)
![image](https://github.com/user-attachments/assets/1e84c3ff-a1b2-46ff-afe8-533ccd256ed8) (canvas rubric of same submission)
but hopefully a less confusing and/or a better type of confusing for students