### PR TITLE
Head hash missing improvement

### DIFF
--- a/src/main/java/edu/byu/cs/analytics/CommitAnalytics.java
+++ b/src/main/java/edu/byu/cs/analytics/CommitAnalytics.java
@@ -240,7 +240,7 @@ public class CommitAnalytics {
     private static CommitsBetweenBounds produceCommitIterable(Git git, ObjectId headObjId, ObjectId tailObjId)
             throws IncorrectObjectTypeException, MissingObjectException, GitAPIException {
         try {
-            return new CommitsBetweenBounds(git.log().addRange(headObjId, tailObjId).call(), false);
+            return new CommitsBetweenBounds(git.log().addRange(tailObjId, headObjId).call(), false);
         } catch (MissingObjectException missingObjectException) {
             return produceCommitIterable(git, headObjId, true);
         }

--- a/src/main/java/edu/byu/cs/analytics/CommitAnalytics.java
+++ b/src/main/java/edu/byu/cs/analytics/CommitAnalytics.java
@@ -1,5 +1,6 @@
 package edu.byu.cs.analytics;
 
+import edu.byu.cs.autograder.git.CommitsBetweenBounds;
 import edu.byu.cs.canvas.CanvasException;
 import edu.byu.cs.canvas.CanvasService;
 import edu.byu.cs.canvas.model.CanvasSection;
@@ -61,7 +62,7 @@ public class CommitAnalytics {
 
         // Prepare data for repeated calculation
         DiffFormatter diffFormatter = prepareDiffFormatter(git);
-        Iterable<RevCommit> commits = getCommitsBetweenBounds(git, upperBound.commitHash(), lowerBound.commitHash());
+        CommitsBetweenBounds commitsBetweenBounds = getCommitsBetweenBounds(git, upperBound.commitHash(), lowerBound.commitHash());
         long lowerTimeBoundSecs = lowerBound.timestamp().getEpochSecond();
         long upperTimeBoundSecs = upperBound.timestamp().getEpochSecond();
 
@@ -79,10 +80,15 @@ public class CommitAnalytics {
         Map<Long, List<String>> commitsByTimestamp = new HashMap<>();
         boolean commitsWithSameTimestamp = false;
 
+        boolean missingTailHash = commitsBetweenBounds.missingTail();
+        if (missingTailHash) {
+            groupCommitsByKey(erroringCommits, "missingTailHash", lowerBound.commitHash());
+        }
+
         // Iteration helpers
         CommitTimestamps commitTimes;
         String commitHash;
-        for (RevCommit rc : commits) {
+        for (RevCommit rc : commitsBetweenBounds.commits()) {
             commitTimes = getCommitTime(rc);
             commitHash = rc.getName();
             if (commitTimes.seconds <= lowerTimeBoundSecs) {
@@ -137,7 +143,7 @@ public class CommitAnalytics {
         return new CommitsByDay(
                 days, changesPerCommit, erroringCommits,
                 singleParentCommits, mergeCommits,
-                commitsInOrder, commitsInFuture, commitsInPast, commitsBackdated, commitsWithSameTimestamp,
+                commitsInOrder, commitsInFuture, commitsInPast, commitsBackdated, commitsWithSameTimestamp, missingTailHash,
                 lowerBound, upperBound);
     }
 
@@ -191,7 +197,26 @@ public class CommitAnalytics {
         return parents;
     }
 
-    private static Iterable<RevCommit> getCommitsBetweenBounds(
+    /**
+     * Responsible for providing an iterable of the commits to analyze for this phase,
+     * along with some status flags indicating how they were retrieved.
+     *
+     * Generally, this will result in only the new commits since the last submission being evaluated.
+     * However, if the previous submission commit is missing, or if this is the first submission,
+     * then the entire history will be provided.
+     *
+     * If a tail commit was expected, but not found, that will be reported as a flag.
+     *
+     * @param git An open Git repo
+     * @param headHash The current head hash to evaluate.
+     * @param tailHash The previous submission head hash, if any.
+     * @return {@link CommitsBetweenBounds} containing the iterable of commits and other flags.
+     * @throws IncorrectObjectTypeException When the GitAPI is used incorrectly.
+     * @throws MissingObjectException When the ead hash cannot be found. If the tailhash cannot be found,
+     * the entire history will be evaluated and the issue flagged.
+     * @throws GitAPIException When the GitAPI has an issue
+     */
+    private static CommitsBetweenBounds getCommitsBetweenBounds(
             Git git, @NonNull String headHash, @Nullable String tailHash)
             throws IncorrectObjectTypeException, MissingObjectException, GitAPIException {
         if (git == null || headHash == null) {
@@ -201,10 +226,23 @@ public class CommitAnalytics {
         ObjectId headObjId = ObjectId.fromString(headHash);
 
         if (tailHash == null) {
-            return git.log().add(headObjId).call();
+            return produceCommitIterable(git, headObjId, false);
         } else {
             ObjectId tailObjId = ObjectId.fromString(tailHash);
-            return git.log().addRange(tailObjId, headObjId).call();
+            return produceCommitIterable(git, headObjId, tailObjId);
+        }
+    }
+
+    private static CommitsBetweenBounds produceCommitIterable(Git git, ObjectId headObjId, boolean missingTail)
+            throws IncorrectObjectTypeException, MissingObjectException, GitAPIException {
+        return new CommitsBetweenBounds(git.log().add(headObjId).call(), missingTail);
+    }
+    private static CommitsBetweenBounds produceCommitIterable(Git git, ObjectId headObjId, ObjectId tailObjId)
+            throws IncorrectObjectTypeException, MissingObjectException, GitAPIException {
+        try {
+            return new CommitsBetweenBounds(git.log().addRange(headObjId, tailObjId).call(), false);
+        } catch (MissingObjectException missingObjectException) {
+            return produceCommitIterable(git, headObjId, true);
         }
     }
 

--- a/src/main/java/edu/byu/cs/analytics/CommitsByDay.java
+++ b/src/main/java/edu/byu/cs/analytics/CommitsByDay.java
@@ -25,6 +25,7 @@ import java.util.Map;
  * @param commitsInFuture Reports whether any commits were found after the end point chronologically.
  * @param commitsBackdated Reports whether any commit was detected to have been backdated.
  * @param commitTimestampsDuplicated Reports where any two commits were discovered to have the same timestamp.
+ * @param missingTailHash Reports when a tail hash was expected to exist, but the commit could not be found.
  * @param lowerThreshold The {@link CommitThreshold}, exclusive.
  * @param upperThreshold The {@link CommitThreshold}, inclusive.
  */
@@ -39,6 +40,7 @@ public record CommitsByDay(
         boolean commitsInPast,
         boolean commitsBackdated,
         boolean commitTimestampsDuplicated,
+        boolean missingTailHash,
         CommitThreshold lowerThreshold,
         CommitThreshold upperThreshold
 ) { }

--- a/src/main/java/edu/byu/cs/autograder/GradingObserver.java
+++ b/src/main/java/edu/byu/cs/autograder/GradingObserver.java
@@ -3,15 +3,51 @@ package edu.byu.cs.autograder;
 import edu.byu.cs.model.Submission;
 
 public interface GradingObserver {
+    /**
+     * Initializes the student grading process by marking the student queue item as "started",
+     * and sending a message to the user.
+     * <br>
+     * This must be called at the very beginning of the grading process.
+     */
     void notifyStarted();
 
+    /**
+     * Sends a normal textual update to the user which typically appears in gray to the user.
+     * @param message A message to report to the student.
+     */
     void update(String message);
 
+    /**
+     * **DESTRUCTIVELY** Closes the connection to the student while reporting an error.
+     * <br>
+     * This should typically only be called from the Grader class.
+     *
+     * @param message A message to report to the student.
+     */
     void notifyError(String message);
 
+    /**
+     * **DESTRUCTIVELY** Closes the connection to the student while reporting an error.
+     * <br>
+     * This should typically only be called from the Grader class.
+     *
+     * @param message A message to report to the student.
+     * @param submission A submission to send to the student, reporting status to the student without saving anywhere.
+     */
     void notifyError(String message, Submission submission);
 
+    /**
+     * Sends a warning to the user which will be displayed in yellow text.
+     * @param message A message to report to the user.
+     */
     void notifyWarning(String message);
 
+    /**
+     * **TERMINALLY** Closes the connection to the student while reporting success.
+     * <br>
+     * Finishes by removing the student from the queue.
+     *
+     * @param submission A submission to send to the student, reporting status to the student without saving anywhere.
+     */
     void notifyDone(Submission submission);
 }

--- a/src/main/java/edu/byu/cs/autograder/git/CommitVerificationResult.java
+++ b/src/main/java/edu/byu/cs/autograder/git/CommitVerificationResult.java
@@ -15,6 +15,7 @@ import java.time.Instant;
  * @param totalCommits Total number of relevant commits analyzed. Excludes merges and commits before the tail threshold.
  * @param significantCommits Total number of commits above the minimum line threshold.
  * @param numDays The number of unique days with commits. Insignificant commits contribute to this number.
+ * @param missingTail Error flag indicates when a tail hash was expected but not found during evaluation.
  * @param penaltyPct A reduction to the phase, if any, when a TA approved an unapproved score. [0-100]
  * @param failureMessage A string that will be presented to the use when this the result is not verified.
  * @param minAllowedThreshold Debug purposes. The min timestamp considered.
@@ -28,6 +29,7 @@ public record CommitVerificationResult(
         int totalCommits,
         int significantCommits,
         int numDays,
+        boolean missingTail,
         int penaltyPct,
         @NonNull String failureMessage,
 

--- a/src/main/java/edu/byu/cs/autograder/git/CommitsBetweenBounds.java
+++ b/src/main/java/edu/byu/cs/autograder/git/CommitsBetweenBounds.java
@@ -1,0 +1,22 @@
+package edu.byu.cs.autograder.git;
+
+import org.eclipse.jgit.revwalk.RevCommit;
+
+/**
+ * Contains all the (new) commits between the bounds of a head-tail has comparison.
+ * <br>
+ * Notably, the resulting commits can only be defined in terms of their commit ancestry,
+ * and not by timestamp. Additional filtering is required down the line to exclude commits
+ * based on time.
+ *
+ * @param commits An iterable of commits.
+ * @param missingTail Reported as true when a tail hash was expected, but not found.
+ *                    This should result in a warning/failed verification.
+ *                    This can occur if a previous submission commit was lost in a rebase,
+ *                    or simply discarded in a destructive repository restart performed by students.
+ */
+public record CommitsBetweenBounds(
+        Iterable<RevCommit> commits,
+        boolean missingTail
+) {
+}

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -111,7 +111,7 @@ public class GitHelper {
         LOGGER.debug("Skipping commit verification. Verified: {}", verified);
         return new CommitVerificationResult(
                 verified, false,
-                0, 0, 0, 0, failureMessage,
+                0, 0, 0, false, 0, failureMessage,
                 Instant.MIN, Instant.MAX,
                 headHash, null
         );
@@ -165,7 +165,7 @@ public class GitHelper {
         String failureMessage = generateFailureMessage(verified, firstPassingSubmission);
         return new CommitVerificationResult(
                 verified, true,
-                0, 0, 0, originalPenaltyPct, failureMessage,
+                0, 0, 0, false, originalPenaltyPct, failureMessage,
                 null, null, headHash, null
         );
     }
@@ -245,6 +245,7 @@ public class GitHelper {
                 numCommits,
                 (int) significantCommits,
                 daysWithCommits,
+                commitsByDay.missingTailHash(),
                 0, // Penalties are applied by TA's upon approval of unapproved submissions
                 String.join("\n", errorMessages),
                 commitsByDay.lowerThreshold().timestamp(),

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -95,9 +95,7 @@ public class GitHelper {
         try (Git git = cloneCommand.call()) {
             LOGGER.info("Cloned repo to {}", git.getRepository().getDirectory());
         } catch (GitAPIException e) {
-            gradingContext.observer().notifyError("Failed to clone repo: " + e.getMessage());
-            LOGGER.error("Failed to clone repo", e);
-            throw new GradingException("Failed to clone repo: " + e.getMessage());
+            throw new GradingException("Failed to clone repo: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -67,7 +67,7 @@ public class GitHelper {
         } catch (GradingException e) {
             // Grading can continue, we'll just alert them of the error.
             String errorStr = "Internally failed to evaluate commit history: " + e.getMessage();
-            gradingContext.observer().update(errorStr);
+            gradingContext.observer().notifyWarning(errorStr);
             LOGGER.error("Failed to evaluate commit history", e);
             return skipCommitVerification(false, headHash, errorStr);
         }
@@ -145,10 +145,7 @@ public class GitHelper {
                 return verifyRegularCommits(git, lowerThreshold, upperThreshold);
             }
         } catch (IOException | GitAPIException | DataAccessException e) {
-            var observer = gradingContext.observer();
-            observer.notifyError("Failed to verify commits: " + e.getMessage());
-            LOGGER.error("Failed to verify commits", e);
-            throw new GradingException("Failed to verify commits: " + e.getMessage());
+            throw new GradingException("Failed to verify commits: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -232,7 +232,10 @@ public class GitHelper {
                         "Suspicious commit history. Some commits have been backdated."),
                 new CV(
                         commitsByDay.commitTimestampsDuplicated(),
-                        "Suspicious commit history. Multiple commits have the exact same timestamp.")
+                        "Suspicious commit history. Multiple commits have the exact same timestamp."),
+                new CV(
+                        commitsByDay.missingTailHash(),
+                        "Missing tail hash. The previous submission commit could not be found in the repository."),
         };
         ArrayList<String> errorMessages = evaluateConditions(assertedConditions, commitVerificationPenaltyPct);
 

--- a/src/main/java/edu/byu/cs/controller/SubmissionController.java
+++ b/src/main/java/edu/byu/cs/controller/SubmissionController.java
@@ -363,7 +363,7 @@ public class SubmissionController {
                 notifyError(message, Map.of("results", Serializer.serialize(submission)));
             }
 
-            public void notifyError(String message, Map<String, Object> contents) {
+            private void notifyError(String message, Map<String, Object> contents) {
                 contents = new HashMap<>(contents);
                 contents.put( "type", "error");
                 contents.put("message", message);

--- a/src/test/java/edu/byu/cs/autograder/git/GitHelperTest.java
+++ b/src/test/java/edu/byu/cs/autograder/git/GitHelperTest.java
@@ -179,7 +179,7 @@ class GitHelperTest {
                     utils.makeCommit(repoContext, "Change 9", 21, 31, 1);
                     utils.makeCommit(repoContext, "Change 10", 20, 30, 900); // Significant
                 },
-                utils.generalCommitVerificationResult(false, 4, 10, 5)
+                utils.generalCommitVerificationResult(false, 4, 10, 5, false)
         ));
     }
 

--- a/src/test/java/edu/byu/cs/autograder/git/GitHelperUtils.java
+++ b/src/test/java/edu/byu/cs/autograder/git/GitHelperUtils.java
@@ -134,16 +134,19 @@ public class GitHelperUtils {
     }
 
     CommitVerificationResult generalCommitVerificationResult(boolean verified, int allCommitsSignificant, int numDays) {
-        return generalCommitVerificationResult(verified, allCommitsSignificant, allCommitsSignificant, numDays);
+        return generalCommitVerificationResult(verified, allCommitsSignificant, allCommitsSignificant, numDays, false);
+    }
+    CommitVerificationResult generalCommitVerificationResult(boolean verified, int allCommitsSignificant, int numDays, boolean missingTail) {
+        return generalCommitVerificationResult(verified, allCommitsSignificant, allCommitsSignificant, numDays, missingTail);
     }
     CommitVerificationResult generalCommitVerificationResult(
-            boolean verified, int significantCommits, int totalCommits, int numDays) {
+            boolean verified, int significantCommits, int totalCommits, int numDays, boolean missingTail) {
         // Note: Unfortunately, we were not able to configure Mockito to properly accept these `any` object times
         // to also accept null. We've moved a different direction now, but we're preserving the `Mockito.nullable/any()`
         // for clarity. They still work, and hopefully we can return to them.
         return new CommitVerificationResult(
-                verified, false, totalCommits, significantCommits, numDays, 0,
-                null, null, null,
+                verified, false, totalCommits, significantCommits, numDays,
+                missingTail, 0, null, null, null,
                 "ANY_HEAD_HASH", null);
     }
 
@@ -240,6 +243,7 @@ public class GitHelperUtils {
         Assertions.assertEquals(expected.totalCommits(), actual.totalCommits());
         Assertions.assertEquals(expected.significantCommits(), actual.significantCommits());
         Assertions.assertEquals(expected.numDays(), actual.numDays());
+        Assertions.assertEquals(expected.missingTail(), actual.missingTail());
         Assertions.assertEquals(expected.penaltyPct(), actual.penaltyPct());
     }
 }

--- a/src/test/java/edu/byu/cs/autograder/git/GitHelperUtils.java
+++ b/src/test/java/edu/byu/cs/autograder/git/GitHelperUtils.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 public class GitHelperUtils {
 
-    private GradingContext gradingContext;
     static final String TEST_REPO_DIR_ROOT = "src/test/resources/gitTestRepos";
     /**
      * Much more destructive by nature;
@@ -34,12 +33,45 @@ public class GitHelperUtils {
     private static final boolean CLEANUP_TEST_REPOS_AFTER_EACH = true;
     private static final String COMMIT_AUTHOR_EMAIL = "cosmo@cs.byu.edu";
 
+    private GradingContext gradingContext;
+    private CommitVerificationResult prevVerification;
+
     public GitHelperUtils() {
         gradingContext = generateGradingContext(10, 3, 10, 1);
     }
 
     public void setGradingContext(GradingContext gradingContext) {
         this.gradingContext = gradingContext;
+    }
+
+    public CommitVerificationResult getPrevVerification() {
+        return prevVerification;
+    }
+    public void setPrevVerification(String newHeadHash) {
+        if (prevVerification != null) {
+            prevVerification = new CommitVerificationResult(
+                    prevVerification.verified(),
+                    prevVerification.isCachedResponse(),
+                    prevVerification.totalCommits(),
+                    prevVerification.significantCommits(),
+                    prevVerification.numDays(),
+                    prevVerification.missingTail(),
+                    prevVerification.penaltyPct(),
+                    prevVerification.failureMessage(),
+                    prevVerification.minAllowedThreshold(),
+                    prevVerification.maxAllowedThreshold(),
+                    newHeadHash,                                // REPLACE HEAD HASH!
+                    prevVerification.tailHash()
+            );
+        } else {
+            prevVerification = new CommitVerificationResult(
+                    false, true, 0, 0, 0, false,
+                    0, "", null, null,
+                    newHeadHash, "");
+        }
+    }
+    public void setPrevVerification(CommitVerificationResult prevVerification) {
+        this.prevVerification = prevVerification;
     }
 
 
@@ -72,7 +104,7 @@ public class GitHelperUtils {
      * @param checkpoints A list of checkpoints to evaluate in the same directory, sequentially
      */
     void evaluateTest(String testName, List<VerificationCheckpoint> checkpoints) {
-        CommitVerificationResult prevVerification = null;
+        prevVerification = null;
 
         try (RepoContext repoContext = initializeTest(testName, "file.txt")) {
             CommitVerificationResult verificationResult;

--- a/src/test/java/edu/byu/cs/autograder/score/ScorerTest.java
+++ b/src/test/java/edu/byu/cs/autograder/score/ScorerTest.java
@@ -268,7 +268,7 @@ class ScorerTest {
         String headHash = "<" + statusStr + "_COMMIT_VERIFICATION>";
 
         return new CommitVerificationResult(
-                verified, isCached, 0, 0, 0, 0,
+                verified, isCached, 0, 0, 0, false, 0,
                 "", null, null,
                 headHash, null);
     }


### PR DESCRIPTION
This changes the behavior when errors arise during commit verification. With this change, grading will continue and ultimately report "unverified;" a TA will be able to approve the submission like with other issues.  It also provides additional documentation to prevent future misunderstandings in the future.

This specifically changes the behavior when a student requests grading for a new phase when their previous submission commit is missing. This was happening frequently as students recreated repos between the GitHub phase and Phase 0, typically due to folder issues.

Resolves #420.