### PR TITLE
Manage Repo URLs in the Autograder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,3 @@ build/
 /logs/
 /phases/
 /commit-cache/
-/validation_cloning/

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ build/
 /logs/
 /phases/
 /commit-cache/
+/validation_cloning/

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -66,7 +66,7 @@ public class GitHelper {
                     skipCommitVerification(true, headHash, null);
         } catch (GradingException e) {
             // Grading can continue, we'll just alert them of the error.
-            String errorStr = "Internally failed to evaluate commit history: " + e.getMessage();
+            String errorStr = "Internally failed to evaluate commit history: " + e.getMessage() + " (this could happen because the repo url has been changed since the last phase, or the student did something to their commit history)";
             gradingContext.observer().update(errorStr);
             LOGGER.error("Failed to evaluate commit history", e);
             return skipCommitVerification(false, headHash, errorStr);
@@ -146,7 +146,7 @@ public class GitHelper {
             }
         } catch (IOException | GitAPIException | DataAccessException e) {
             var observer = gradingContext.observer();
-            observer.notifyError("Failed to verify commits: " + e.getMessage());
+            observer.notifyWarning("Failed to verify commits: " + e.getMessage());
             LOGGER.error("Failed to verify commits", e);
             throw new GradingException("Failed to verify commits: " + e.getMessage());
         }

--- a/src/main/java/edu/byu/cs/canvas/CanvasIntegration.java
+++ b/src/main/java/edu/byu/cs/canvas/CanvasIntegration.java
@@ -69,16 +69,6 @@ public interface CanvasIntegration {
      */
     CanvasSubmission getSubmission(int userId, int assignmentNum) throws CanvasException;
 
-    /**
-     * Gets the git repository url for the given user from their GitHub Repository assignment submission on canvas
-     *
-     * @param userId The canvas user id of the user to get the git repository url for
-     * @return The git repository url for the given user
-     * @throws CanvasException If there is an error with Canvas
-     */
-    String getGitRepo(int userId) throws CanvasException;
-
-
     User getTestStudent() throws CanvasException;
 
     ZonedDateTime getAssignmentDueDateForStudent(int userId, int assignmentId) throws CanvasException;

--- a/src/main/java/edu/byu/cs/canvas/CanvasIntegrationImpl.java
+++ b/src/main/java/edu/byu/cs/canvas/CanvasIntegrationImpl.java
@@ -65,17 +65,7 @@ public class CanvasIntegrationImpl implements CanvasIntegration {
                 String firstName = ((names.length >= 2) ? names[1] : "").trim();
                 String lastName = ((names.length >= 1) ? names[0] : "").trim();
 
-                String repoUrl = (role == User.Role.STUDENT) ? getGitRepo(user.id()) : null;
-
-                if (role == User.Role.STUDENT) {
-                    try {
-                        SubmissionUtils.getRemoteHeadHash(repoUrl);
-                    } catch (RuntimeException e) {
-                        throw new CanvasException("Invalid repo url. Please resubmit the GitHub Repository assignment on Canvas");
-                    }
-                }
-
-                return new User(netId, user.id(), firstName, lastName, repoUrl, role);
+                return new User(netId, user.id(), firstName, lastName, null, role);
             }
         }
 
@@ -199,28 +189,6 @@ public class CanvasIntegrationImpl implements CanvasIntegration {
         ).body();
     }
 
-    /**
-     * Gets the git repository url for the given user from their GitHub Repository assignment submission on canvas
-     *
-     * @param userId The canvas user id of the user to get the git repository url for
-     * @return The git repository url for the given user
-     * @throws CanvasException If there is an error with Canvas
-     */
-    @Override
-    public String getGitRepo(int userId) throws CanvasException {
-        CanvasSubmission submission = getSubmission(userId, getGitHubAssignmentNumber());
-
-        if (submission == null)
-            throw new CanvasException("Error while accessing GitHub Repository assignment submission on canvas");
-
-        if (submission.url() == null)
-            throw new CanvasException(
-                    "The Github Repository assignment submission on Canvas must be submitted before accessing the autograder"
-            );
-
-        return submission.url();
-    }
-
     @Override
     public User getTestStudent() throws CanvasException {
         String testStudentName = "Test%20Student";
@@ -233,17 +201,12 @@ public class CanvasIntegrationImpl implements CanvasIntegration {
         if (users.length == 0)
             throw new CanvasException("Test Student not found in Canvas");
 
-        String repoUrl = getGitRepo(users[0].id());
-
-        if (repoUrl == null)
-            throw new CanvasException("Test Student has not submitted the GitHub Repository assignment on Canvas");
-
         return new User(
                 "test",
                 users[0].id(),
                 "Test",
                 "Student",
-                repoUrl,
+                null,
                 User.Role.STUDENT
         );
     }

--- a/src/main/java/edu/byu/cs/canvas/FakeCanvasIntegration.java
+++ b/src/main/java/edu/byu/cs/canvas/FakeCanvasIntegration.java
@@ -53,11 +53,6 @@ public class FakeCanvasIntegration implements CanvasIntegration {
     }
 
     @Override
-    public String getGitRepo(int userId) {
-        return null;
-    }
-
-    @Override
     public User getTestStudent() {
         return null;
     }

--- a/src/main/java/edu/byu/cs/controller/AdminController.java
+++ b/src/main/java/edu/byu/cs/controller/AdminController.java
@@ -45,6 +45,30 @@ public class AdminController {
 
     };
 
+    public static final Route userGet = (req, res) -> {
+        UserDao userDao = DaoService.getUserDao();
+        String netId = req.params(":netId");
+
+        User user;
+        try {
+            user = userDao.getUser(netId);
+        } catch (DataAccessException e) {
+            LOGGER.error("Error getting user", e);
+            halt(500);
+            return null;
+        }
+
+        if (user == null) {
+            halt(404, "User " + netId + " not found");
+        }
+
+        res.type("application/json");
+        res.status(200);
+
+        return Serializer.serialize(user);
+
+    };
+
     public static final Route userPatch = (req, res) -> {
         String netId = req.params(":netId");
 

--- a/src/main/java/edu/byu/cs/controller/AdminController.java
+++ b/src/main/java/edu/byu/cs/controller/AdminController.java
@@ -45,30 +45,6 @@ public class AdminController {
 
     };
 
-    public static final Route userGet = (req, res) -> {
-        UserDao userDao = DaoService.getUserDao();
-        String netId = req.params(":netId");
-
-        User user;
-        try {
-            user = userDao.getUser(netId);
-        } catch (DataAccessException e) {
-            LOGGER.error("Error getting user", e);
-            halt(500);
-            return null;
-        }
-
-        if (user == null) {
-            halt(404, "User " + netId + " not found");
-        }
-
-        res.type("application/json");
-        res.status(200);
-
-        return Serializer.serialize(user);
-
-    };
-
     public static final Route userPatch = (req, res) -> {
         String netId = req.params(":netId");
 

--- a/src/main/java/edu/byu/cs/controller/CasController.java
+++ b/src/main/java/edu/byu/cs/controller/CasController.java
@@ -46,6 +46,7 @@ public class CasController {
         UserDao userDao = DaoService.getUserDao();
 
         User user;
+        // Check if student is already in the database
         try {
             user = userDao.getUser(netId);
         } catch (DataAccessException e) {
@@ -54,24 +55,16 @@ public class CasController {
             return null;
         }
 
+        // If there isn't a student in the database with this netId
         if (user == null) {
             try {
                 user = CanvasService.getCanvasIntegration().getUser(netId);
             } catch (CanvasException e) {
-                LOGGER.error("Couldn't create user from Canvas", e);
+                LOGGER.error("Error getting user from canvas", e);
 
                 String errorUrlParam = URLEncoder.encode(e.getMessage(), StandardCharsets.UTF_8);
                 res.redirect(ApplicationProperties.frontendUrl() + "/login?error=" + errorUrlParam, 302);
                 halt(500);
-                return null;
-            }
-
-            if (userDao.repoUrlClaimed(user.repoUrl())) {
-                LOGGER.error("Repo URL already claimed: {}", user.repoUrl());
-
-                String errorUrlParam = URLEncoder.encode("Repo URL already claimed. Meet with a TA for help resolving this.", StandardCharsets.UTF_8);
-                res.redirect(ApplicationProperties.frontendUrl() + "/login?error=" + errorUrlParam, 302);
-                halt(400, "Repo URL already claimed");
                 return null;
             }
 

--- a/src/main/java/edu/byu/cs/controller/SubmissionController.java
+++ b/src/main/java/edu/byu/cs/controller/SubmissionController.java
@@ -42,8 +42,6 @@ public class SubmissionController {
             halt(400, "Student submission is disabled for " + request.phase());
         }
 
-        updateRepoFromCanvas(user, req);
-
         if (! verifyHasNewCommits(user, request.phase()) ) { return null; }
 
         LOGGER.info("User {} submitted phase {} for grading", user.netId(), request.phase());
@@ -111,16 +109,6 @@ public class SubmissionController {
         } catch (Exception e) {
             LOGGER.error("Error starting grader", e);
             halt(500);
-        }
-    }
-
-    private static void updateRepoFromCanvas(User user, Request req) throws CanvasException, DataAccessException {
-        CanvasIntegration canvas = CanvasService.getCanvasIntegration();
-        String newRepoUrl = canvas.getGitRepo(user.canvasUserId());
-        if (!newRepoUrl.equals(user.repoUrl())) {
-            user = new User(user.netId(), user.canvasUserId(), user.firstName(), user.lastName(), newRepoUrl, user.role());
-            DaoService.getUserDao().setRepoUrl(user.netId(), newRepoUrl);
-            req.session().attribute("user", user);
         }
     }
 

--- a/src/main/java/edu/byu/cs/controller/UserController.java
+++ b/src/main/java/edu/byu/cs/controller/UserController.java
@@ -185,7 +185,7 @@ public class UserController {
                 Instant fakeUpdateInstant = mountainTime.toInstant();
 
                 if (updateDao.getUpdatesForUser(user.netId()).isEmpty()) {
-                    updateDao.insertUpdate(new RepoUpdate(fakeUpdateInstant, user.netId(), user.repoUrl(), true, "Canvas"));
+                    updateDao.insertUpdate(new RepoUpdate(fakeUpdateInstant, user.netId(), cleanRepoUrl(user.repoUrl()), true, "Canvas"));
                 }
             }
         } catch (DataAccessException e) {

--- a/src/main/java/edu/byu/cs/controller/UserController.java
+++ b/src/main/java/edu/byu/cs/controller/UserController.java
@@ -1,0 +1,48 @@
+package edu.byu.cs.controller;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import edu.byu.cs.autograder.GradingException;
+import edu.byu.cs.dataAccess.DaoService;
+import edu.byu.cs.dataAccess.UserDao;
+import edu.byu.cs.model.User;
+import org.eclipse.jgit.api.CloneCommand;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import spark.Route;
+
+import static spark.Spark.halt;
+
+public class UserController {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserController.class);
+
+    public static final Route repoPatch = (req, res) -> {
+        User user = req.session().attribute("user");
+
+        String repoUrl = req.queryParams("repoUrl");
+
+        if (!isValidRepoUrl(repoUrl)) {
+            halt(400, "invalid github repo");
+        }
+
+        DaoService.getUserDao().setRepoUrl(user.netId(), repoUrl);
+        LOGGER.info("{} changed their repoUrl to {}", user.netId(), repoUrl);
+
+        res.status(200);
+        return "Successfully updated repoUrl";
+    };
+
+    private static boolean isValidRepoUrl(String url) {
+        CloneCommand cloneCommand = Git.cloneRepository().setURI(url);
+
+        try (Git git = cloneCommand.call()) {
+            LOGGER.info("Test cloning git repo to {}", git.getRepository().getDirectory());
+        } catch (GitAPIException e) {
+            LOGGER.error("Failed to clone repo", e);
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/edu/byu/cs/controller/UserController.java
+++ b/src/main/java/edu/byu/cs/controller/UserController.java
@@ -162,12 +162,14 @@ public class UserController {
 
     /**
      * cleans up and returns the provided GitHub Repo URL for consistent formatting.
-     * currently just removes the .git at the end of the URL if present
      */
     private static String cleanRepoUrl(String url) {
         if (url == null) { return null; }
         if (url.endsWith(".git")) {
             url = url.substring(0, url.length() - 4);
+        }
+        if (url.startsWith("https://www.")) {
+            url = "https://" + url.substring(12);
         }
         return url;
     }

--- a/src/main/java/edu/byu/cs/controller/UserController.java
+++ b/src/main/java/edu/byu/cs/controller/UserController.java
@@ -2,9 +2,7 @@ package edu.byu.cs.controller;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import edu.byu.cs.autograder.GradingException;
 import edu.byu.cs.dataAccess.DaoService;
-import edu.byu.cs.dataAccess.UserDao;
 import edu.byu.cs.model.User;
 import edu.byu.cs.util.FileUtils;
 import org.eclipse.jgit.api.CloneCommand;
@@ -15,7 +13,6 @@ import org.slf4j.LoggerFactory;
 import spark.Route;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.UUID;
 
 import static spark.Spark.halt;
@@ -31,7 +28,8 @@ public class UserController {
 
         try {
             if (!isValidRepoUrl(repoUrl)) {
-                halt(400, "Invalid Github Repo Url. Check if the link is valid");
+                res.status(400);
+                return "Invalid Github Repo Url. Check if the link is valid and points directly to a Github Repo.";
             }
         } catch (Exception e) {
             LOGGER.error("Error cloning repo during repoPatch: " + e.getMessage());
@@ -45,7 +43,7 @@ public class UserController {
         return "Successfully updated repoUrl";
     };
 
-    private static boolean isValidRepoUrl(String url) throws IOException {
+    private static boolean isValidRepoUrl(String url) {
         File cloningDir = new File("./validation_cloning/" + UUID.randomUUID());
         CloneCommand cloneCommand = Git.cloneRepository().setURI(url).setDirectory(cloningDir);
 

--- a/src/main/java/edu/byu/cs/controller/UserController.java
+++ b/src/main/java/edu/byu/cs/controller/UserController.java
@@ -4,6 +4,8 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import edu.byu.cs.dataAccess.DaoService;
 import edu.byu.cs.dataAccess.DataAccessException;
+import edu.byu.cs.dataAccess.UserDao;
+import edu.byu.cs.dataAccess.sql.RepoUpdateDao;
 import edu.byu.cs.model.RepoUpdate;
 import edu.byu.cs.model.User;
 import edu.byu.cs.util.FileUtils;
@@ -17,7 +19,7 @@ import spark.HaltException;
 import spark.Route;
 
 import java.io.File;
-import java.time.Instant;
+import java.time.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
@@ -54,7 +56,6 @@ public class UserController {
     };
 
     public static final Route repoHistoryAdminGet = (req, res) -> {
-        Gson gson = new Gson();
         String repoUrl = req.queryParams("repoUrl");
         String netId = req.queryParams("netId");
 
@@ -148,6 +149,10 @@ public class UserController {
      * @return null if the repo is available for that user. returns the update that prevents the user from claiming the url.
      */
     private static RepoUpdate verifyRepoIsAvailableForUser(String url, String netId) throws DataAccessException {
+        if (netId.equals("test")) {
+            loadCurrentReposIntoUpdateTable();
+        }
+
         Collection<RepoUpdate> updates = DaoService.getRepoUpdateDao().getUpdatesForRepo(url);
         if (updates.isEmpty()) {
             return null;
@@ -158,6 +163,34 @@ public class UserController {
             }
         }
         return null;
+    }
+
+    // TODO: Remove this code soon or figure out a better way to do this
+    // This loads all the repo urls in the user table into the update table so they can be compared
+    // This will not be needed in future semesters, since updates will be logged from the start
+    private static void loadCurrentReposIntoUpdateTable() {
+        RepoUpdateDao updateDao = DaoService.getRepoUpdateDao();
+        UserDao userDao = DaoService.getUserDao();
+
+        try {
+            Collection<User> users = userDao.getUsers();
+            int minuteOffset = 0;
+            int hourOffset = 0;
+            for (User user : users) {
+                if (user.role() == User.Role.ADMIN) { continue; }
+                minuteOffset = (minuteOffset == 59) ? 0 : minuteOffset + 1;
+                hourOffset = (minuteOffset == 0) ? hourOffset + 1 : hourOffset;
+                LocalDateTime fakeUpdateTime = LocalDateTime.of(2024, 9, 4, hourOffset, minuteOffset);
+                ZonedDateTime mountainTime = fakeUpdateTime.atZone(ZoneId.of("America/Denver"));
+                Instant fakeUpdateInstant = mountainTime.toInstant();
+
+                if (updateDao.getUpdatesForUser(user.netId()).isEmpty()) {
+                    updateDao.insertUpdate(new RepoUpdate(fakeUpdateInstant, user.netId(), user.repoUrl(), true, "Canvas"));
+                }
+            }
+        } catch (DataAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/src/main/java/edu/byu/cs/controller/UserController.java
+++ b/src/main/java/edu/byu/cs/controller/UserController.java
@@ -128,7 +128,7 @@ public class UserController {
     }
 
     private static boolean isValidRepoUrl(String url) {
-        File cloningDir = new File("./validation_cloning/" + UUID.randomUUID());
+        File cloningDir = new File("./tmp" + UUID.randomUUID());
         CloneCommand cloneCommand = Git.cloneRepository().setURI(url).setDirectory(cloningDir);
 
         try (Git git = cloneCommand.call()) {

--- a/src/main/java/edu/byu/cs/dataAccess/DaoService.java
+++ b/src/main/java/edu/byu/cs/dataAccess/DaoService.java
@@ -10,6 +10,7 @@ public class DaoService {
     private static QueueDao queueDao = new QueueMemoryDao();
     private static RubricConfigDao rubricConfigDao = new RubricConfigMemoryDao();
     private static ConfigurationDao configurationDao = new ConfigurationMemoryDao();
+    private static RepoUpdateDao repoUpdateDao = new RepoUpdateMemoryDao();
 
     public static UserDao getUserDao() {
         return userDao;
@@ -51,6 +52,12 @@ public class DaoService {
         DaoService.configurationDao = configurationDao;
     }
 
+    public static void setRepoUpdateDao(RepoUpdateDao repoUpdateDao) {
+        DaoService.repoUpdateDao = repoUpdateDao;
+    }
+
+    public static RepoUpdateDao getRepoUpdateDao() { return repoUpdateDao; }
+
     /** Create and set a memory DAO for every DAO. Used for testing purposes. */
     public static void initializeMemoryDAOs() {
         DaoService.setRubricConfigDao(new RubricConfigMemoryDao());
@@ -58,6 +65,7 @@ public class DaoService {
         DaoService.setQueueDao(new QueueMemoryDao());
         DaoService.setSubmissionDao(new SubmissionMemoryDao());
         DaoService.setConfigurationDao(new ConfigurationMemoryDao());
+        DaoService.setRepoUpdateDao(new RepoUpdateMemoryDao());
     }
 
     public static void initializeSqlDAOs() throws DataAccessException {
@@ -67,5 +75,6 @@ public class DaoService {
         DaoService.setRubricConfigDao(new RubricConfigSqlDao());
         DaoService.setSubmissionDao(new SubmissionSqlDao());
         DaoService.setUserDao(new UserSqlDao());
+        DaoService.setRepoUpdateDao(new RepoUpdateSqlDao());
     }
 }

--- a/src/main/java/edu/byu/cs/dataAccess/memory/RepoUpdateMemoryDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/memory/RepoUpdateMemoryDao.java
@@ -1,0 +1,36 @@
+package edu.byu.cs.dataAccess.memory;
+
+import edu.byu.cs.dataAccess.DataAccessException;
+import edu.byu.cs.dataAccess.sql.RepoUpdateDao;
+import edu.byu.cs.model.RepoUpdate;
+
+import java.util.Collection;
+import java.util.Deque;
+import java.util.LinkedList;
+
+public class RepoUpdateMemoryDao implements RepoUpdateDao {
+    private final Deque<RepoUpdate> repoUpdates = new LinkedList<>();
+
+    @Override
+    public void insertUpdate(RepoUpdate update) throws DataAccessException {
+        repoUpdates.add(update);
+    }
+
+    @Override
+    public Collection<RepoUpdate> getUpdatesForUser(String netId) throws DataAccessException {
+        return repoUpdates
+                .stream()
+                .filter(update ->
+                        update.netId().equals(netId))
+                .toList();
+    }
+
+    @Override
+    public Collection<RepoUpdate> getUpdatesForRepo(String repoUrl) throws DataAccessException {
+        return repoUpdates
+                .stream()
+                .filter(update ->
+                        update.repoUrl().equals(repoUrl))
+                .toList();
+    }
+}

--- a/src/main/java/edu/byu/cs/dataAccess/sql/RepoUpdateDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/sql/RepoUpdateDao.java
@@ -1,0 +1,28 @@
+package edu.byu.cs.dataAccess.sql;
+
+import edu.byu.cs.dataAccess.DataAccessException;
+import edu.byu.cs.model.RepoUpdate;
+
+import java.util.Collection;
+
+public interface RepoUpdateDao {
+    /**
+     * Inserts an update into the database
+     * @param update
+     */
+    void insertUpdate(RepoUpdate update) throws DataAccessException;
+
+    /**
+     * Gets all updates to a user's repo
+     * @param netId user to get update history for
+     * @return all updates to their repo
+     */
+    Collection<RepoUpdate> getUpdatesForUser(String netId) throws DataAccessException;
+
+    /**
+     * Gets all updates with a specific repo
+     * @param repoUrl the repo to get all updates for
+     * @return
+     */
+    Collection<RepoUpdate> getUpdatesForRepo(String repoUrl) throws DataAccessException;
+}

--- a/src/main/java/edu/byu/cs/dataAccess/sql/RepoUpdateSqlDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/sql/RepoUpdateSqlDao.java
@@ -1,0 +1,61 @@
+package edu.byu.cs.dataAccess.sql;
+
+import edu.byu.cs.dataAccess.DataAccessException;
+import edu.byu.cs.dataAccess.sql.helpers.ColumnDefinition;
+import edu.byu.cs.dataAccess.sql.helpers.SqlReader;
+import edu.byu.cs.model.RepoUpdate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Collection;
+
+public class RepoUpdateSqlDao implements RepoUpdateDao {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RepoUpdateSqlDao.class);
+
+    private final SqlReader<RepoUpdate> sqlReader = new SqlReader<RepoUpdate>(
+            "repo_update", COLUMN_DEFINITIONS, RepoUpdateSqlDao::readUpdate);
+    private static final ColumnDefinition[] COLUMN_DEFINITIONS = {
+            new ColumnDefinition<RepoUpdate>("timestamp", s -> Timestamp.from(s.timestamp())),
+            new ColumnDefinition<RepoUpdate>("net_id", RepoUpdate::netId),
+            new ColumnDefinition<RepoUpdate>("repo_url", RepoUpdate::repoUrl),
+            new ColumnDefinition<RepoUpdate>("admin_update", RepoUpdate::adminUpdate),
+            new ColumnDefinition<RepoUpdate>("admin_net_id", RepoUpdate::adminNetId),
+    };
+
+    private static RepoUpdate readUpdate(ResultSet rs) throws SQLException {
+        Instant timestamp = rs.getTimestamp("timestamp").toInstant();
+        String netId = rs.getString("net_id");
+        String repoUrl = rs.getString("repo_url");
+        Boolean passed = rs.getBoolean("admin_update");
+        String headHash = rs.getString("admin_net_id");
+
+        return new RepoUpdate(timestamp, netId, repoUrl, passed, headHash);
+    }
+
+
+    @Override
+    public void insertUpdate(RepoUpdate update) throws DataAccessException {
+        sqlReader.insertItem(update);
+    }
+
+    @Override
+    public Collection<RepoUpdate> getUpdatesForUser(String netId) throws DataAccessException {
+        return sqlReader.executeQuery(
+                "WHERE net_id = ?",
+                ps -> ps.setString(1, netId)
+        );
+    }
+
+    @Override
+    public Collection<RepoUpdate> getUpdatesForRepo(String repoUrl) throws DataAccessException {
+        return sqlReader.executeQuery(
+                "WHERE repo_url = ?",
+                ps -> ps.setString(1, repoUrl)
+        );
+    }
+}

--- a/src/main/java/edu/byu/cs/dataAccess/sql/SqlDb.java
+++ b/src/main/java/edu/byu/cs/dataAccess/sql/SqlDb.java
@@ -102,6 +102,18 @@ public class SqlDb {
                             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
                         """);
             }
+            try (Statement createConfigurationTableStatement = connection.createStatement()) {
+                createConfigurationTableStatement.executeUpdate("""
+                        CREATE TABLE IF NOT EXISTS `repo_update` (
+                               `timestamp` TIMESTAMP NOT NULL,
+                               `net_id` VARCHAR(255) NOT NULL,
+                               `repo_url` VARCHAR(2048) NOT NULL,
+                               `admin_update` BOOLEAN NOT NULL,
+                               `admin_net_id` VARCHAR(255),
+                               PRIMARY KEY (`timestamp`)
+                            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+                        """);
+            }
         } catch (SQLException e) {
             LOGGER.error("Error connecting to database", e);
             throw new DataAccessException("Error connecting to database", e);

--- a/src/main/java/edu/byu/cs/model/RepoUpdate.java
+++ b/src/main/java/edu/byu/cs/model/RepoUpdate.java
@@ -22,11 +22,11 @@ public record RepoUpdate(
 
         @Override
         public String toString() {
-                String adminInfo = adminUpdate ? "adminNetId='" + adminNetId + '\'' : "";
+                String adminInfo = adminUpdate ? "\nadminNetId='" + adminNetId + '\'' : "";
                 return "RepoUpdate{" +
-                        "timestamp=" + timestamp +
-                        ", netId='" + netId + '\'' +
-                        ", repoUrl='" + repoUrl + '\'' +
+                        "Timestamp:" + timestamp +
+                        "\nnetId='" + netId + '\'' +
+                        "\nrepoUrl='" + repoUrl + '\'' +
                         adminInfo +
                         '}';
         }

--- a/src/main/java/edu/byu/cs/model/RepoUpdate.java
+++ b/src/main/java/edu/byu/cs/model/RepoUpdate.java
@@ -1,0 +1,22 @@
+package edu.byu.cs.model;
+
+import org.eclipse.jgit.annotations.Nullable;
+
+import java.time.Instant;
+
+/**
+ * Represents an update to a student's repo url so that changes can be logged in the database
+ * @param timestamp When the repo url was updated
+ * @param netId The netId of the student whose repo url was changed
+ * @param repoUrl The new repoUrl
+ * @param adminUpdate Flags if the url was updated by an admin
+ * @param adminNetId Null if update was done by a student, will contain the admin's netId if an admin updated it
+ */
+public record RepoUpdate(
+        Instant timestamp,
+        String netId,
+        String repoUrl,
+        boolean adminUpdate,
+        @Nullable String adminNetId
+        ) {
+}

--- a/src/main/java/edu/byu/cs/model/RepoUpdate.java
+++ b/src/main/java/edu/byu/cs/model/RepoUpdate.java
@@ -22,11 +22,9 @@ public record RepoUpdate(
 
         @Override
         public String toString() {
-                String adminInfo = adminUpdate ? "\nadminNetId='" + adminNetId + '\'' : "";
+                String adminInfo = adminUpdate ? " by admin '" + adminNetId + ' ' : "";
                 return "RepoUpdate{" +
-                        "Timestamp:" + timestamp +
-                        "\nnetId='" + netId + '\'' +
-                        "\nrepoUrl='" + repoUrl + '\'' +
+                        netId + " to " + repoUrl + " at " + timestamp +
                         adminInfo +
                         '}';
         }

--- a/src/main/java/edu/byu/cs/model/RepoUpdate.java
+++ b/src/main/java/edu/byu/cs/model/RepoUpdate.java
@@ -19,4 +19,15 @@ public record RepoUpdate(
         boolean adminUpdate,
         @Nullable String adminNetId
         ) {
+
+        @Override
+        public String toString() {
+                String adminInfo = adminUpdate ? "adminNetId='" + adminNetId + '\'' : "";
+                return "RepoUpdate{" +
+                        "timestamp=" + timestamp +
+                        ", netId='" + netId + '\'' +
+                        ", repoUrl='" + repoUrl + '\'' +
+                        adminInfo +
+                        '}';
+        }
 }

--- a/src/main/java/edu/byu/cs/server/Server.java
+++ b/src/main/java/edu/byu/cs/server/Server.java
@@ -77,7 +77,7 @@ public class Server {
                         verifyAdminMiddleware.handle(req, res);
                 });
 
-                patch("repo/:netId", repoPatchAdmin);
+                patch("/repo/:netId", repoPatchAdmin);
 
                 get("/users", usersGet);
 

--- a/src/main/java/edu/byu/cs/server/Server.java
+++ b/src/main/java/edu/byu/cs/server/Server.java
@@ -20,8 +20,7 @@ import static edu.byu.cs.controller.AuthController.*;
 import static edu.byu.cs.controller.CasController.*;
 import static edu.byu.cs.controller.ConfigController.*;
 import static edu.byu.cs.controller.SubmissionController.*;
-import static edu.byu.cs.controller.UserController.repoPatch;
-import static edu.byu.cs.controller.UserController.repoPatchAdmin;
+import static edu.byu.cs.controller.UserController.*;
 import static spark.Spark.*;
 
 public class Server {
@@ -78,6 +77,8 @@ public class Server {
                 });
 
                 patch("/repo/:netId", repoPatchAdmin);
+
+                get("/repo/history", repoHistoryAdminGet);
 
                 get("/users", usersGet);
 

--- a/src/main/java/edu/byu/cs/server/Server.java
+++ b/src/main/java/edu/byu/cs/server/Server.java
@@ -20,6 +20,7 @@ import static edu.byu.cs.controller.AuthController.*;
 import static edu.byu.cs.controller.CasController.*;
 import static edu.byu.cs.controller.ConfigController.*;
 import static edu.byu.cs.controller.SubmissionController.*;
+import static edu.byu.cs.controller.UserController.repoPatch;
 import static spark.Spark.*;
 
 public class Server {
@@ -54,6 +55,8 @@ public class Server {
                 if (!req.requestMethod().equals("OPTIONS"))
                     verifyAuthenticatedMiddleware.handle(req, res);
             });
+
+            patch("/repo", repoPatch);
 
             get("/submit", submitGet);
             post("/submit", submitPost);

--- a/src/main/java/edu/byu/cs/server/Server.java
+++ b/src/main/java/edu/byu/cs/server/Server.java
@@ -21,6 +21,7 @@ import static edu.byu.cs.controller.CasController.*;
 import static edu.byu.cs.controller.ConfigController.*;
 import static edu.byu.cs.controller.SubmissionController.*;
 import static edu.byu.cs.controller.UserController.repoPatch;
+import static edu.byu.cs.controller.UserController.repoPatchAdmin;
 import static spark.Spark.*;
 
 public class Server {
@@ -75,6 +76,8 @@ public class Server {
                     if (!req.requestMethod().equals("OPTIONS"))
                         verifyAdminMiddleware.handle(req, res);
                 });
+
+                patch("repo/:netId", repoPatchAdmin);
 
                 get("/users", usersGet);
 

--- a/src/main/java/edu/byu/cs/server/Server.java
+++ b/src/main/java/edu/byu/cs/server/Server.java
@@ -82,8 +82,6 @@ public class Server {
 
                 get("/users", usersGet);
 
-                get("/user/:netId", userGet);
-
                 patch("/user/:netId", userPatch);
 
                 post("/submit", adminRepoSubmitPost);

--- a/src/main/java/edu/byu/cs/server/Server.java
+++ b/src/main/java/edu/byu/cs/server/Server.java
@@ -81,6 +81,8 @@ public class Server {
 
                 get("/users", usersGet);
 
+                get("/user/:netId", userGet);
+
                 patch("/user/:netId", userPatch);
 
                 post("/submit", adminRepoSubmitPost);

--- a/src/main/resources/frontend/src/App.vue
+++ b/src/main/resources/frontend/src/App.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, reactive } from 'vue'
 import {useAuthStore} from "@/stores/auth";
-import { logoutPost } from '@/services/authService'
+import { loadUser, logoutPost } from '@/services/authService'
 import router from '@/router'
 import '@/assets/fontawesome/css/fontawesome.css'
 import '@/assets/fontawesome/css/solid.css'
 import { useAppConfigStore } from '@/stores/appConfig'
+import PopUp from '@/components/PopUp.vue'
+import RepoEditor from '@/components/RepoEditor.vue'
 
 const greeting = computed(() => {
   if (useAuthStore().isLoggedIn) {
@@ -33,6 +35,13 @@ const bannerMessage = computed(() => {
 onMounted( async () => {
   await useAppConfigStore().updateConfig();
 })
+
+const openRepoEditor = reactive({value: false})
+
+const repoEditDone = () => {
+  openRepoEditor.value = false
+  loadUser()
+}
 </script>
 
 <template>
@@ -40,12 +49,28 @@ onMounted( async () => {
     <h1>CS 240 Autograder</h1>
     <h3>This is where you can submit your assignments and view your scores.</h3>
     <p>{{ greeting }} <a v-if="useAuthStore().isLoggedIn" @click="logOut">Logout</a></p>
-    <p>{{ useAuthStore().user?.repoUrl }}</p>
+    <p
+      v-if="useAuthStore().user?.repoUrl"
+      @click="openRepoEditor.value = true"
+      id="repoLink"
+    >
+      {{ useAuthStore().user?.repoUrl }}
+      <i class="fa-solid fa-pen-to-square"/>
+    </p>
+
     <div v-if="bannerMessage" id="bannerMessage">
       <span v-text="bannerMessage"/>
     </div>
   </header>
   <main>
+    <PopUp
+      id="repoEditorPopUp"
+      v-if="openRepoEditor.value"
+      @closePopUp="openRepoEditor.value = false">
+      <RepoEditor
+      @repoEditSuccess="repoEditDone"/>
+    </PopUp>
+
     <router-view/>
   </main>
 </template>
@@ -75,6 +100,10 @@ h1 {
   font-weight: bold;
 }
 
+#repoLink {
+  cursor: pointer;
+}
+
 main {
   display: flex;
   flex-direction: column;
@@ -93,6 +122,10 @@ a {
   color: white;
   text-decoration: underline;
   cursor: pointer;
+}
+
+#repoEditorPopUp {
+  text-align: center;
 }
 
 @media only screen and (max-width: 600px) {

--- a/src/main/resources/frontend/src/App.vue
+++ b/src/main/resources/frontend/src/App.vue
@@ -68,7 +68,7 @@ const repoEditDone = () => {
       v-if="openRepoEditor.value"
       @closePopUp="openRepoEditor.value = false">
       <RepoEditor
-      @repoEditSuccess="repoEditDone" :user="null"/>
+      @repoEditSuccess="repoEditDone" :user="useAuthStore().user"/>
     </PopUp>
 
     <router-view/>

--- a/src/main/resources/frontend/src/App.vue
+++ b/src/main/resources/frontend/src/App.vue
@@ -68,7 +68,7 @@ const repoEditDone = () => {
       v-if="openRepoEditor.value"
       @closePopUp="openRepoEditor.value = false">
       <RepoEditor
-      @repoEditSuccess="repoEditDone"/>
+      @repoEditSuccess="repoEditDone" :user="null"/>
     </PopUp>
 
     <router-view/>

--- a/src/main/resources/frontend/src/components/RepoEditor.vue
+++ b/src/main/resources/frontend/src/components/RepoEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { isPlausibleRepoUrl } from '@/utils/utils'
-import { defineEmits, reactive } from 'vue'
+import { defineEmits, onMounted, reactive } from 'vue'
 import { adminUpdateRepoPatch, studentUpdateRepoPatch } from '@/services/userService'
 import type { User } from '@/types/types'
 
@@ -40,11 +40,15 @@ const submitAndCheckRepo = async (sendEmit: (event: any) => void) => {
   success.value = true
   sendEmit('repoEditSuccess')
 }
+
+onMounted( () => {
+  console.log(user)
+})
 </script>
 
 <template>
 <div>
-  <p><em>Please enter <span>{{user ? user.netId + "'s new" : "your"}}</span> GitHub Repo link here:</em></p>
+  <p><em>Please enter the GitHub Repo link here:</em></p>
   <input v-model="newRepoUrl.value" type="text" id="repoUrlInput" placeholder="Github Repo URL"/>
   <button
     :disabled="waitingForRepoCheck.value || !isPlausibleRepoUrl(newRepoUrl.value)"

--- a/src/main/resources/frontend/src/components/RepoEditor.vue
+++ b/src/main/resources/frontend/src/components/RepoEditor.vue
@@ -6,7 +6,7 @@ import type { User } from '@/types/types'
 import { useAuthStore } from '@/stores/auth'
 
 const { user } = defineProps<{
-  user: User;
+  user: User | null;
 }>();
 
 defineEmits({
@@ -24,7 +24,7 @@ const submitAndCheckRepo = async (sendEmit: (event: any) => void) => {
   waitingForRepoCheck.value = true
 
   try {
-    if (useAuthStore().user?.role == 'ADMIN') {
+    if (useAuthStore().user?.role == 'ADMIN' && user != null) {
       await adminUpdateRepoPatch(newRepoUrl.value, user.netId)
     } else {
       await studentUpdateRepoPatch(newRepoUrl.value)

--- a/src/main/resources/frontend/src/components/RepoEditor.vue
+++ b/src/main/resources/frontend/src/components/RepoEditor.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { isPlausibleRepoUrl } from '@/utils/utils'
+import { reactive } from 'vue'
+import { studentUpdateRepo } from '@/services/userService'
+
+
+let studentRepo = reactive( {
+  value: ""
+})
+let waitingForRepoCheck = reactive({ value: false })
+
+const submitAndCheckRepo = async () => {
+  waitingForRepoCheck.value = true
+
+  try {
+    await studentUpdateRepo(studentRepo.value)
+
+  } catch (error) {
+    if (error instanceof Error) { alert("Failed to save your Github Repo: " + error.message) }
+    else { alert("Unknown error updating Github Repo") }
+    waitingForRepoCheck.value = false
+    return
+  }
+
+  // Get ending action from props
+  window.location.href = '/'
+}
+</script>
+
+<template>
+<div>
+  <p><em>Please enter your GitHub Repo link here:</em></p>
+  <input v-model="studentRepo.value" type="text" id="repoUrlInput" placeholder="Github Repo URL"/>
+  <button
+    :disabled="waitingForRepoCheck.value || !isPlausibleRepoUrl(studentRepo.value)"
+    class="primary"
+    @click="submitAndCheckRepo">Submit and Register</button>
+  <p v-if="waitingForRepoCheck.value">Verifying repo URL... please wait...</p>
+  <div id="urlTips">
+    <p>Your url should look something like this:</p>
+    <p><em>https://github.com/{username}/{name_of_project}</em></p>
+  </div>
+</div>
+</template>
+
+<style scoped>
+#repoUrlInput {
+  width: 80%;
+  padding: 10px;
+  margin-right: 10px;
+}
+#urlTips {
+  font-size: smaller;
+  flex-direction: column;
+}
+button {
+  margin: 5px;
+}
+</style>

--- a/src/main/resources/frontend/src/components/RepoEditor.vue
+++ b/src/main/resources/frontend/src/components/RepoEditor.vue
@@ -1,15 +1,18 @@
 <script setup lang="ts">
 import { isPlausibleRepoUrl } from '@/utils/utils'
-import { reactive } from 'vue'
+import { defineEmits, reactive } from 'vue'
 import { studentUpdateRepo } from '@/services/userService'
 
+defineEmits({
+  repoEditSuccess: null,
+});
 
 let studentRepo = reactive( {
   value: ""
 })
 let waitingForRepoCheck = reactive({ value: false })
 
-const submitAndCheckRepo = async () => {
+const submitAndCheckRepo = async (sendEmit: (event: any) => void) => {
   waitingForRepoCheck.value = true
 
   try {
@@ -22,8 +25,7 @@ const submitAndCheckRepo = async () => {
     return
   }
 
-  // Get ending action from props
-  window.location.href = '/'
+  sendEmit('repoEditSuccess')
 }
 </script>
 
@@ -34,7 +36,7 @@ const submitAndCheckRepo = async () => {
   <button
     :disabled="waitingForRepoCheck.value || !isPlausibleRepoUrl(studentRepo.value)"
     class="primary"
-    @click="submitAndCheckRepo">Submit and Register</button>
+    @click="submitAndCheckRepo($emit)">Submit and Save</button>
   <p v-if="waitingForRepoCheck.value">Verifying repo URL... please wait...</p>
   <div id="urlTips">
     <p>Your url should look something like this:</p>

--- a/src/main/resources/frontend/src/components/RepoEditor.vue
+++ b/src/main/resources/frontend/src/components/RepoEditor.vue
@@ -3,9 +3,10 @@ import { isPlausibleRepoUrl } from '@/utils/utils'
 import { defineEmits, onMounted, reactive } from 'vue'
 import { adminUpdateRepoPatch, studentUpdateRepoPatch } from '@/services/userService'
 import type { User } from '@/types/types'
+import { useAuthStore } from '@/stores/auth'
 
 const { user } = defineProps<{
-  user: User | null;
+  user: User;
 }>();
 
 defineEmits({
@@ -23,7 +24,7 @@ const submitAndCheckRepo = async (sendEmit: (event: any) => void) => {
   waitingForRepoCheck.value = true
 
   try {
-    if (user) {
+    if (useAuthStore().user?.role == 'ADMIN') {
       await adminUpdateRepoPatch(newRepoUrl.value, user.netId)
     } else {
       await studentUpdateRepoPatch(newRepoUrl.value)

--- a/src/main/resources/frontend/src/components/RepoEditor.vue
+++ b/src/main/resources/frontend/src/components/RepoEditor.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { isPlausibleRepoUrl } from '@/utils/utils'
 import { defineEmits, reactive } from 'vue'
-import { adminUpdateRepo, studentUpdateRepo } from '@/services/userService'
+import { adminUpdateRepoPatch, studentUpdateRepoPatch } from '@/services/userService'
 import type { User } from '@/types/types'
 
 const { user } = defineProps<{
@@ -24,9 +24,9 @@ const submitAndCheckRepo = async (sendEmit: (event: any) => void) => {
 
   try {
     if (user) {
-      await adminUpdateRepo(newRepoUrl.value, user.netId)
+      await adminUpdateRepoPatch(newRepoUrl.value, user.netId)
     } else {
-      await studentUpdateRepo(newRepoUrl.value)
+      await studentUpdateRepoPatch(newRepoUrl.value)
     }
 
   } catch (error) {
@@ -51,6 +51,7 @@ const submitAndCheckRepo = async (sendEmit: (event: any) => void) => {
     class="primary"
     @click="submitAndCheckRepo($emit)">Submit and Save</button>
   <p v-if="waitingForRepoCheck.value">Verifying repo URL... please wait...</p>
+  <p v-else-if="success.value">Repo successfully saved!</p>
   <div id="urlTips">
     <p>The url should look something like this:</p>
     <p><em>https://github.com/{username}/{name_of_project}</em></p>

--- a/src/main/resources/frontend/src/components/RepoEditor.vue
+++ b/src/main/resources/frontend/src/components/RepoEditor.vue
@@ -30,7 +30,7 @@ const submitAndCheckRepo = async (sendEmit: (event: any) => void) => {
     }
 
   } catch (error) {
-    if (error instanceof Error) { alert("Failed to save the Github Repo: " + error.message) }
+    if (error instanceof Error) { alert("Failed to save the Github Repo: \n" + error.message) }
     else { alert("Unknown error updating Github Repo") }
     waitingForRepoCheck.value = false
     return

--- a/src/main/resources/frontend/src/router/index.ts
+++ b/src/main/resources/frontend/src/router/index.ts
@@ -29,6 +29,8 @@ const router = createRouter({
             beforeEnter: (to, from) => {
                 if (useAuthStore().isFullyRegistered)
                     return '/'
+                if (!useAuthStore().isLoggedIn)
+                    return 'login'
             }
         },
         {

--- a/src/main/resources/frontend/src/router/index.ts
+++ b/src/main/resources/frontend/src/router/index.ts
@@ -3,6 +3,7 @@ import HomeView from "@/views/HomeView.vue";
 import LoginView from "@/views/LoginView.vue";
 import {useAuthStore} from "@/stores/auth";
 import AdminView from "@/views/AdminView/AdminView.vue";
+import RegisterView from '@/views/RegisterView.vue'
 
 const router = createRouter({
     history: createWebHistory(import.meta.env.BASE_URL),
@@ -15,8 +16,19 @@ const router = createRouter({
                 if (!useAuthStore().isLoggedIn)
                     // query must be included for login error messages to work correctly
                     return {name: 'login', query: to.query}
+                if (!useAuthStore().isFullyRegistered)
+                    return '/register'
                 if (useAuthStore().user?.role === 'ADMIN')
                     return '/admin'
+            }
+        },
+        {
+            path: '/register',
+            name: 'register',
+            component: RegisterView,
+            beforeEnter: (to, from) => {
+                if (useAuthStore().isFullyRegistered)
+                    return '/'
             }
         },
         {

--- a/src/main/resources/frontend/src/services/authService.ts
+++ b/src/main/resources/frontend/src/services/authService.ts
@@ -1,4 +1,5 @@
 import {useAppConfigStore} from "@/stores/appConfig";
+import { useAuthStore } from '@/stores/auth'
 
 type MeResponse = {
     netId: string,
@@ -18,6 +19,14 @@ export const meGet = async () => {
     } catch (e) {
         return null;
     }
+}
+
+export const loadUser = async () => {
+    const loggedInUser = await meGet()
+    if (loggedInUser == null)
+        return;
+
+    useAuthStore().user = loggedInUser;
 }
 
 export const logoutPost = async () => {

--- a/src/main/resources/frontend/src/services/authService.ts
+++ b/src/main/resources/frontend/src/services/authService.ts
@@ -20,19 +20,6 @@ export const meGet = async () => {
     }
 }
 
-export const registerPost = async (firstName: string, lastName: string, repoUrl: string) => {
-    const response = await fetch(useAppConfigStore().backendUrl + '/auth/register', {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({firstName, lastName, repoUrl})
-    });
-
-    return response.ok;
-}
-
 export const logoutPost = async () => {
     const response = await fetch(useAppConfigStore().backendUrl + "/auth/logout", {
         method: 'POST',

--- a/src/main/resources/frontend/src/services/userService.ts
+++ b/src/main/resources/frontend/src/services/userService.ts
@@ -1,0 +1,19 @@
+import {useAppConfigStore} from "@/stores/appConfig";
+
+export const studentUpdateRepo = async (repoUrl: String): Promise<void> => {
+  const response = await fetch(useAppConfigStore().backendUrl + '/api/repo', {
+    method: 'PATCH',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      "repoUrl": repoUrl
+    })
+  });
+
+  if (!response.ok) {
+    console.error(response);
+    throw new Error(await response.text());
+  }
+}

--- a/src/main/resources/frontend/src/services/userService.ts
+++ b/src/main/resources/frontend/src/services/userService.ts
@@ -1,14 +1,32 @@
 import {useAppConfigStore} from "@/stores/appConfig";
+import type { User } from '@/types/types'
 
-export const studentUpdateRepo = async (repoUrl: String): Promise<void> => {
-  await updateRepo(repoUrl, '/api/repo')
+export const userGet = async (netId: String): Promise<User | null> => {
+  const response = await fetch(useAppConfigStore().backendUrl + "/api/admin/user/" + netId, {
+    method: 'GET',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    console.error(response);
+    throw new Error(await response.text());
+  }
+
+  return await response.json() as User | null;
 }
 
-export const adminUpdateRepo = async (repoUrl: String, netId: String): Promise<void> => {
-  await updateRepo(repoUrl, "/api/admin/repo/" + netId)
+export const studentUpdateRepoPatch = async (repoUrl: String): Promise<void> => {
+  await updateRepoPatch(repoUrl, '/api/repo')
 }
 
-const updateRepo = async (repoUrl: String, endpoint: String): Promise<void> => {
+export const adminUpdateRepoPatch = async (repoUrl: String, netId: String): Promise<void> => {
+  await updateRepoPatch(repoUrl, "/api/admin/repo/" + netId)
+}
+
+const updateRepoPatch = async (repoUrl: String, endpoint: String): Promise<void> => {
   const response = await fetch(useAppConfigStore().backendUrl + endpoint, {
     method: 'PATCH',
     credentials: 'include',

--- a/src/main/resources/frontend/src/services/userService.ts
+++ b/src/main/resources/frontend/src/services/userService.ts
@@ -1,7 +1,15 @@
 import {useAppConfigStore} from "@/stores/appConfig";
 
 export const studentUpdateRepo = async (repoUrl: String): Promise<void> => {
-  const response = await fetch(useAppConfigStore().backendUrl + '/api/repo', {
+  await updateRepo(repoUrl, '/api/repo')
+}
+
+export const adminUpdateRepo = async (repoUrl: String, netId: String): Promise<void> => {
+  await updateRepo(repoUrl, "/api/admin/repo/" + netId)
+}
+
+const updateRepo = async (repoUrl: String, endpoint: String): Promise<void> => {
+  const response = await fetch(useAppConfigStore().backendUrl + endpoint, {
     method: 'PATCH',
     credentials: 'include',
     headers: {

--- a/src/main/resources/frontend/src/services/userService.ts
+++ b/src/main/resources/frontend/src/services/userService.ts
@@ -1,23 +1,5 @@
 import {useAppConfigStore} from "@/stores/appConfig";
-import type { RepoUpdate, Submission, User } from '@/types/types'
-import { Phase } from '@/types/types'
-
-export const userGet = async (netId: String): Promise<User | null> => {
-  const response = await fetch(useAppConfigStore().backendUrl + "/api/admin/user/" + netId, {
-    method: 'GET',
-    credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json'
-    }
-  });
-
-  if (!response.ok) {
-    console.error(response);
-    throw new Error(await response.text());
-  }
-
-  return await response.json() as User | null;
-}
+import type { RepoUpdate } from '@/types/types'
 
 export const repoHistoryGet = async (netId: String): Promise<RepoUpdate[]> => {
   let url = useAppConfigStore().backendUrl + '/api/admin/repo/history?netId=' + netId

--- a/src/main/resources/frontend/src/services/userService.ts
+++ b/src/main/resources/frontend/src/services/userService.ts
@@ -1,5 +1,6 @@
 import {useAppConfigStore} from "@/stores/appConfig";
-import type { User } from '@/types/types'
+import type { RepoUpdate, Submission, User } from '@/types/types'
+import { Phase } from '@/types/types'
 
 export const userGet = async (netId: String): Promise<User | null> => {
   const response = await fetch(useAppConfigStore().backendUrl + "/api/admin/user/" + netId, {
@@ -17,6 +18,21 @@ export const userGet = async (netId: String): Promise<User | null> => {
 
   return await response.json() as User | null;
 }
+
+export const repoHistoryGet = async (netId: String): Promise<RepoUpdate[]> => {
+  let url = useAppConfigStore().backendUrl + '/api/admin/repo/history?netId=' + netId
+  const response = await fetch(url, {
+    method: 'GET',
+    credentials: 'include'
+  });
+
+  if (!response.ok) {
+    console.error(response);
+    return [];
+  }
+
+  return await response.json() as RepoUpdate[];
+};
 
 export const studentUpdateRepoPatch = async (repoUrl: String): Promise<void> => {
   await updateRepoPatch(repoUrl, '/api/repo')

--- a/src/main/resources/frontend/src/stores/auth.ts
+++ b/src/main/resources/frontend/src/stores/auth.ts
@@ -15,5 +15,15 @@ export const useAuthStore = defineStore('auth', () => {
     const token = document.cookie.split('; ').find(row => row.startsWith('token'))?.split('=')[1] || '';
 
     const isLoggedIn = computed(() => user.value !== null)
-    return {user, token, isLoggedIn}
+
+    const isFullyRegistered = computed(() => {
+        const user = useAuthStore().user
+        if (user == null) { return false }
+        if (user.role == 'STUDENT') {
+            if (!user.repoUrl) { return false }
+        }
+        return true
+    } )
+
+    return {user, token, isLoggedIn, isFullyRegistered}
 })

--- a/src/main/resources/frontend/src/types/types.ts
+++ b/src/main/resources/frontend/src/types/types.ts
@@ -98,3 +98,11 @@ export type CanvasSection = {
     id: number,
     name: string
 }
+
+export type RepoUpdate = {
+    timestamp: string,
+    netId: string,
+    repoUrl: string,
+    adminUpdate: boolean,
+    adminNetId: string | null
+}

--- a/src/main/resources/frontend/src/utils/tableUtils.ts
+++ b/src/main/resources/frontend/src/utils/tableUtils.ts
@@ -19,7 +19,7 @@ export const renderTimestampCell = (params: ValueGetterParams):string => {
  * @param params is an ValueGetterParams Object from AG-Grid that contains a field called "repoUrl"
  */
 export const renderRepoLinkCell = (params: ValueGetterParams):string => {
-    return generateClickableLink(params.data.repoUrl)
+    return params.data.repoUrl ? generateClickableLink(params.data.repoUrl) : ""
 }
 
 /**

--- a/src/main/resources/frontend/src/utils/utils.ts
+++ b/src/main/resources/frontend/src/utils/utils.ts
@@ -1,5 +1,13 @@
 import {useAdminStore} from "@/stores/admin";
-import {Phase, type RubricItem, type RubricType, type Submission, type TestNode, VerifiedStatus} from '@/types/types'
+import {
+  Phase,
+  type RubricItem,
+  type RubricType,
+  type Submission,
+  type TestNode,
+  type User,
+  VerifiedStatus
+} from '@/types/types'
 import {useAuthStore} from '@/stores/auth'
 
 export const commitVerificationFailed = (submission: Submission) => {
@@ -151,4 +159,3 @@ export const convertRubricTypeToHumanReadable = (rubricType: RubricType): string
   const words = rubricType.split('_').map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase());
   return words.join(' ');
 }
-

--- a/src/main/resources/frontend/src/utils/utils.ts
+++ b/src/main/resources/frontend/src/utils/utils.ts
@@ -159,3 +159,8 @@ export const convertRubricTypeToHumanReadable = (rubricType: RubricType): string
   const words = rubricType.split('_').map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase());
   return words.join(' ');
 }
+
+export const isPlausibleRepoUrl = (url: string): boolean => {
+  return url.startsWith("http") &&
+         url.includes("github.com/")
+}

--- a/src/main/resources/frontend/src/views/AdminView/RepoView.vue
+++ b/src/main/resources/frontend/src/views/AdminView/RepoView.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import type { User } from '@/types/types'
+import { generateClickableLink } from '@/utils/utils'
+import RepoEditor from '@/components/RepoEditor.vue'
+import { useAuthStore } from '@/stores/auth'
+import { loadUser } from '@/services/authService'
+
+const { student } = defineProps<{
+  student: User;
+}>();
+
+</script>
+
+<template>
+<div>
+  <h3>GitHub Repo URL for {{student.firstName}} {{student.lastName}}</h3>
+  <p>Current Repo: <span v-html="generateClickableLink(student.repoUrl)"/></p>
+
+  <br/>
+
+  <div id="changeAndHistory">
+    <div>
+      <h4>Change Their Repo</h4>
+      <RepoEditor
+        :user="student"
+         @repoEditSuccess=""/>
+    </div>
+    <div>
+      <h4>Repo Change History</h4>
+      <p><em>Coming soon to an autograder near you</em></p>
+    </div>
+  </div>
+</div>
+</template>
+
+<style scoped>
+#changeAndHistory {
+  display: grid;
+  grid-template-columns: 2fr 3fr;
+  text-align: center;
+}
+</style>

--- a/src/main/resources/frontend/src/views/AdminView/RepoView.vue
+++ b/src/main/resources/frontend/src/views/AdminView/RepoView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { RepoUpdate, Submission, User } from '@/types/types'
-import { generateClickableLink, readableTimestamp, simpleTimestamp } from '@/utils/utils'
+import type { RepoUpdate, User } from '@/types/types'
+import { generateClickableLink, simpleTimestamp } from '@/utils/utils'
 import RepoEditor from '@/components/RepoEditor.vue'
 import { onMounted, ref } from 'vue'
 import { repoHistoryGet } from '@/services/userService'
@@ -10,7 +10,7 @@ const { student } = defineProps<{
 }>();
 
 onMounted(async () => {
-  repoUpdateHistory.value = await repoHistoryGet(student.netId);
+  repoUpdateHistory.value = (await repoHistoryGet(student.netId)).reverse();
 });
 const reloadPage = () => {
   window.location.reload()

--- a/src/main/resources/frontend/src/views/AdminView/RepoView.vue
+++ b/src/main/resources/frontend/src/views/AdminView/RepoView.vue
@@ -9,6 +9,10 @@ const { student } = defineProps<{
   student: User;
 }>();
 
+const reloadPage = () => {
+  window.location.reload()
+}
+
 </script>
 
 <template>
@@ -23,7 +27,8 @@ const { student } = defineProps<{
       <h4>Change Their Repo</h4>
       <RepoEditor
         :user="student"
-         @repoEditSuccess=""/>
+         @repoEditSuccess="reloadPage"/>
+      <p><em>If the repo saves successfully, the page will reload.</em></p>
     </div>
     <div>
       <h4>Repo Change History</h4>

--- a/src/main/resources/frontend/src/views/AdminView/StudentInfo.vue
+++ b/src/main/resources/frontend/src/views/AdminView/StudentInfo.vue
@@ -51,17 +51,18 @@ const rowData = reactive({
 <template>
   <h3>{{student.firstName}} {{student.lastName}}</h3>
   <p>netID: {{student.netId}}</p>
-  <p v-if="student.repoUrl">
+  <p v-if="student.role == 'STUDENT'">
     Github Repo:
-    <span v-html="generateClickableLink(student.repoUrl)"/>
+    <span v-if="student.repoUrl" v-html="generateClickableLink(student.repoUrl)"/>
+    <span v-else>No repo</span>
     <button
+      v-if="student.role == 'STUDENT'"
       class="small"
       id="openRepoView"
       @click="openRepoView.value = true">
       History/Change
     </button>
   </p>
-
 
   <ag-grid-vue
       class="ag-theme-quartz"

--- a/src/main/resources/frontend/src/views/AdminView/StudentInfo.vue
+++ b/src/main/resources/frontend/src/views/AdminView/StudentInfo.vue
@@ -10,6 +10,7 @@ import PopUp from "@/components/PopUp.vue";
 import {renderPhaseCell, renderScoreCell, renderTimestampCell, standardColSettings} from "@/utils/tableUtils";
 import SubmissionInfo from "@/views/StudentView/SubmissionInfo.vue";
 import {generateClickableLink} from "@/utils/utils";
+import RepoView from '@/views/AdminView/RepoView.vue'
 
 const { student } = defineProps<{
   student: User;
@@ -17,6 +18,7 @@ const { student } = defineProps<{
 
 const studentSubmissions = ref<Submission[]>([])
 const selectedSubmission = ref<Submission | null>(null);
+const openRepoView = reactive({value: false})
 
 onMounted(async () => {
   await loadStudentSubmissions()
@@ -49,7 +51,17 @@ const rowData = reactive({
 <template>
   <h3>{{student.firstName}} {{student.lastName}}</h3>
   <p>netID: {{student.netId}}</p>
-  <p v-if="student.repoUrl">Github Repo: <span v-html="generateClickableLink(student.repoUrl)"/> </p>
+  <p v-if="student.repoUrl">
+    Github Repo:
+    <span v-html="generateClickableLink(student.repoUrl)"/>
+    <button
+      class="small"
+      id="openRepoView"
+      @click="openRepoView.value = true">
+      History/Change
+    </button>
+  </p>
+
 
   <ag-grid-vue
       class="ag-theme-quartz"
@@ -65,11 +77,23 @@ const rowData = reactive({
     <SubmissionInfo :submission="selectedSubmission"
                     @approvedSubmission="loadStudentSubmissions"/>
   </PopUp>
+
+  <PopUp
+      v-if="openRepoView.value"
+      @closePopUp="openRepoView.value = false">
+    <RepoView :student="student"/>
+  </PopUp>
 </template>
 
 <style scoped>
 a:visited, a {
   color: darkblue;
   font-style: italic;
+}
+
+#openRepoView  {
+  margin: 5px;
+  font-size: smaller;
+  padding: 2px;
 }
 </style>

--- a/src/main/resources/frontend/src/views/AdminView/StudentsView.vue
+++ b/src/main/resources/frontend/src/views/AdminView/StudentsView.vue
@@ -52,9 +52,8 @@ const activateTestStudentMode = async () => {
 <template>
   <Panel class="test-student-mode-container">
     <div>
-      <p>Use "Test Student Mode" to use the autograder as the course's test student</p>
-      <p>- you will need to log out and back in again to return to admin mode</p>
-      <p>- the test student must have a Github Repo submitted to the Canvas assignment</p>
+      <p>Use "Test Student Mode" to use the autograder as the course's test student.</p>
+      <p>To return to admin mode, just log out and then log in again.</p>
     </div>
     <div>
       <button @click="activateTestStudentMode">Go to Test Student Mode</button>

--- a/src/main/resources/frontend/src/views/AdminView/StudentsView.vue
+++ b/src/main/resources/frontend/src/views/AdminView/StudentsView.vue
@@ -37,7 +37,7 @@ onMounted(async () => {
 const columnDefs = reactive([
   { headerName: "Student Name", field: "name", flex: 2, minWidth: 150, onCellClicked: cellClickHandler },
   { headerName: "BYU netID", field: "netId", flex: 1, minWidth: 75, onCellClicked: cellClickHandler },
-  { headerName: "Github Repo URL", field: "repoUrl", flex: 5, sortable: false, cellRenderer: renderRepoLinkCell }
+  { headerName: "Github Repo URL", field: "repoUrl", flex: 5, sortable: false, cellRenderer: renderRepoLinkCell, onCellClicked: cellClickHandler }
 ])
 const rowData = reactive({
   value: []

--- a/src/main/resources/frontend/src/views/AdminView/SubmissionsView.vue
+++ b/src/main/resources/frontend/src/views/AdminView/SubmissionsView.vue
@@ -15,7 +15,7 @@ import {
   renderTimestampCell
 } from "@/utils/tableUtils";
 import StudentInfo from "@/views/AdminView/StudentInfo.vue";
-import {generateClickableLink, nameFromNetId} from "@/utils/utils";
+import { generateClickableLink, isPlausibleRepoUrl, nameFromNetId } from '@/utils/utils'
 import {adminSubmissionPost} from "@/services/submissionService";
 import SubmissionInfo from '@/views/StudentView/SubmissionInfo.vue'
 import LiveStatus from '@/views/StudentView/LiveStatus.vue'
@@ -127,8 +127,7 @@ const adminSubmit = async () => {
       <button
         :disabled="(selectedAdminPhase === null)
           || useSubmissionStore().currentlyGrading
-          || !adminRepo.value.includes('github.com/')
-          || !adminRepo.value.includes('http')"
+          || !isPlausibleRepoUrl(adminRepo.value)"
         class="primary"
         @click="adminSubmit">Submit</button>
     </div>

--- a/src/main/resources/frontend/src/views/LoginView.vue
+++ b/src/main/resources/frontend/src/views/LoginView.vue
@@ -1,17 +1,13 @@
 <script setup lang="ts">
 import {useAppConfigStore} from "@/stores/appConfig";
 import {onBeforeMount, onMounted} from 'vue';
-import {meGet} from "@/services/authService";
+import { loadUser, meGet } from '@/services/authService'
 import {useAuthStore} from "@/stores/auth";
 import router from "@/router";
 
 onBeforeMount(async () => {
-  const loggedInUser = await meGet()
-  if (loggedInUser == null)
-    return;
-
-  useAuthStore().user = loggedInUser;
-  router.push({ name: 'home' });
+  await loadUser()
+  await router.push({ name: 'home' });
 })
 
 const login = () => {

--- a/src/main/resources/frontend/src/views/RegisterView.vue
+++ b/src/main/resources/frontend/src/views/RegisterView.vue
@@ -31,7 +31,8 @@ const goToApp = () => {
       <span>Click here for more info</span>
     </a>
     <RepoEditor
-      @repoEditSuccess="goToApp"/>
+      @repoEditSuccess="goToApp"
+      :user="useAuthStore().user"/>
   </div>
 </template>
 

--- a/src/main/resources/frontend/src/views/RegisterView.vue
+++ b/src/main/resources/frontend/src/views/RegisterView.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
-import { onBeforeMount, reactive } from 'vue'
+import { onBeforeMount } from 'vue'
 import {meGet} from "@/services/authService";
 import {useAuthStore} from "@/stores/auth";
 import router from "@/router";
-import { isPlausibleRepoUrl } from '@/utils/utils'
 import { uiConfig } from '@/stores/uiConfig'
 import { Phase } from '@/types/types'
-import { studentUpdateRepo } from '@/services/userService'
+import RepoEditor from '@/components/RepoEditor.vue'
 
 onBeforeMount(async () => {
   const loggedInUser = await meGet()
@@ -16,27 +15,6 @@ onBeforeMount(async () => {
   useAuthStore().user = loggedInUser;
   router.push({ name: 'home' });
 })
-
-let studentRepo = reactive( {
-  value: ""
-})
-let waitingForRepoCheck = reactive({ value: false })
-
-const submitAndCheckRepo = async () => {
-  waitingForRepoCheck.value = true
-
-  try {
-    await studentUpdateRepo(studentRepo.value)
-
-  } catch (error) {
-    if (error instanceof Error) { alert("Failed to save your Github Repo: " + error.message) }
-    else { alert("Unknown error updating Github Repo") }
-    waitingForRepoCheck.value = false
-    return
-  }
-
-  window.location.href = '/'
-}
 
 </script>
 
@@ -49,17 +27,7 @@ const submitAndCheckRepo = async () => {
       :href="uiConfig.getSpecLink(Phase.GitHub)">
       <span>Click here for more info</span>
     </a>
-    <p><em>Please enter your GitHub Repo link here:</em></p>
-    <input v-model="studentRepo.value" type="text" id="repoUrlInput" placeholder="Github Repo URL"/>
-    <button
-      :disabled="waitingForRepoCheck.value || !isPlausibleRepoUrl(studentRepo.value)"
-      class="primary"
-      @click="submitAndCheckRepo">Submit and Register</button>
-    <p v-if="waitingForRepoCheck.value">Verifying repo URL... please wait...</p>
-    <div id="urlTips">
-      <p>Your url should look something like this:</p>
-      <p><em>https://github.com/{username}/{name_of_project}</em></p>
-    </div>
+    <RepoEditor/>
   </div>
 </template>
 
@@ -75,14 +43,5 @@ const submitAndCheckRepo = async () => {
 
 button {
   margin-top: 1rem;
-}
-#repoUrlInput {
-  width: 80%;
-  padding: 10px;
-  margin-right: 10px;
-}
-#urlTips {
-  font-size: smaller;
-  flex-direction: column;
 }
 </style>

--- a/src/main/resources/frontend/src/views/RegisterView.vue
+++ b/src/main/resources/frontend/src/views/RegisterView.vue
@@ -55,6 +55,7 @@ const submitAndCheckRepo = async () => {
       :disabled="waitingForRepoCheck.value || !isPlausibleRepoUrl(studentRepo.value)"
       class="primary"
       @click="submitAndCheckRepo">Submit and Register</button>
+    <p v-if="waitingForRepoCheck.value">Verifying repo URL... please wait...</p>
     <div id="urlTips">
       <p>Your url should look something like this:</p>
       <p><em>https://github.com/{username}/{name_of_project}</em></p>

--- a/src/main/resources/frontend/src/views/RegisterView.vue
+++ b/src/main/resources/frontend/src/views/RegisterView.vue
@@ -54,7 +54,11 @@ const submitAndCheckRepo = async () => {
     <button
       :disabled="waitingForRepoCheck.value || !isPlausibleRepoUrl(studentRepo.value)"
       class="primary"
-      @click="submitAndCheckRepo">Submit and Verify</button>
+      @click="submitAndCheckRepo">Submit and Register</button>
+    <div id="urlTips">
+      <p>Your url should look something like this:</p>
+      <p><em>https://github.com/{username}/{name_of_project}</em></p>
+    </div>
   </div>
 </template>
 
@@ -65,6 +69,7 @@ const submitAndCheckRepo = async () => {
   align-items: center;
   justify-content: center;
   height: 100%;
+  text-align: center;
 }
 
 button {
@@ -74,5 +79,9 @@ button {
   width: 80%;
   padding: 10px;
   margin-right: 10px;
+}
+#urlTips {
+  font-size: smaller;
+  flex-direction: column;
 }
 </style>

--- a/src/main/resources/frontend/src/views/RegisterView.vue
+++ b/src/main/resources/frontend/src/views/RegisterView.vue
@@ -16,6 +16,9 @@ onBeforeMount(async () => {
   router.push({ name: 'home' });
 })
 
+const goToApp = () => {
+  window.location.href = '/'
+}
 </script>
 
 <template>
@@ -27,7 +30,8 @@ onBeforeMount(async () => {
       :href="uiConfig.getSpecLink(Phase.GitHub)">
       <span>Click here for more info</span>
     </a>
-    <RepoEditor/>
+    <RepoEditor
+      @repoEditSuccess="goToApp"/>
   </div>
 </template>
 

--- a/src/main/resources/frontend/src/views/RegisterView.vue
+++ b/src/main/resources/frontend/src/views/RegisterView.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
-import {useAppConfigStore} from "@/stores/appConfig";
-import { onBeforeMount, onMounted, reactive } from 'vue'
+import { onBeforeMount, reactive } from 'vue'
 import {meGet} from "@/services/authService";
 import {useAuthStore} from "@/stores/auth";
 import router from "@/router";
-import { useSubmissionStore } from '@/stores/submissions'
 import { isPlausibleRepoUrl } from '@/utils/utils'
 import { uiConfig } from '@/stores/uiConfig'
 import { Phase } from '@/types/types'
-import { adminSubmissionPost } from '@/services/submissionService'
 import { studentUpdateRepo } from '@/services/userService'
-import { useRouter } from 'vue-router'
 
 onBeforeMount(async () => {
   const loggedInUser = await meGet()

--- a/src/main/resources/frontend/src/views/RegisterView.vue
+++ b/src/main/resources/frontend/src/views/RegisterView.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import {useAppConfigStore} from "@/stores/appConfig";
+import {onBeforeMount, onMounted} from 'vue';
+import {meGet} from "@/services/authService";
+import {useAuthStore} from "@/stores/auth";
+import router from "@/router";
+
+onBeforeMount(async () => {
+  const loggedInUser = await meGet()
+  if (loggedInUser == null)
+    return;
+
+  useAuthStore().user = loggedInUser;
+  router.push({ name: 'home' });
+})
+
+
+</script>
+
+<template>
+  <div id="content">
+    <h2>Welcome to the CS 240 Autograder</h2>
+    <p>Please enter your GitHub Repo URL</p>
+    <button @click="">Submit and Verify</button>
+  </div>
+</template>
+
+<style scoped>
+#content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+button {
+  margin-top: 1rem;
+}
+</style>

--- a/src/test/java/integration/CanvasIntegrationImplIT.java
+++ b/src/test/java/integration/CanvasIntegrationImplIT.java
@@ -144,32 +144,6 @@ public class CanvasIntegrationImplIT {
 
     }
 
-    @Test
-    @DisplayName("Test Student repo can be retrieved")
-    @Order(5)
-    public void getTestStudentRepo() {
-        User testStudent = null;
-        try {
-            retriever.useCourseRelatedInfoFromCanvas();
-            testStudent = canvasIntegration.getTestStudent();
-        } catch (CanvasException | DataAccessException e) {
-            fail("Unexpected exception thrown: ", e);
-        }
-        assertNotNull(testStudent, "Test student should not be null");
-
-
-        String testStudentRepo = null;
-        try {
-            testStudentRepo = canvasIntegration.getGitRepo(testStudent.canvasUserId());
-        } catch (CanvasException e) {
-            fail("Unexpected exception thrown: ", e);
-        }
-
-        assertNotNull(testStudentRepo, "Test student repo should not be null. Has it been set in Canvas");
-        assertNotEquals("", testStudentRepo, "Test student repo should not be empty");
-        assertTrue(testStudentRepo.contains("github.com"), "Test student repo is not a github url");
-    }
-
     private static void loadApplicationProperties() {
 
         String canvasToken = System.getenv("CANVAS_API_TOKEN");


### PR DESCRIPTION
### Overview
This pull request moves the management of repo URLs from canvas, and makes it completely managed by the Autograder itself.

Key changes include:
- Canvas is never queried for a student's repo URL
- Students are required to enter a repo URL the first time they log into the Autograder
- Students may change their repo URL anytime within the Autograder
- Admins may change a student's repo URL anytime from the Student Info window
- Changes in repo URLs are tracked, and available for admin inspection on a per-student basis
- Students are blocked from claiming repo URLs claimed by any other student, whether or not it is currently claimed by that student

### Details

#### What counts as a valid repo URL
The front end will not allow students to submit anything as a repo URL that doesn't start with `http` and contains `github.com/`. Its a very surface level check. The backend will then remove (if present) the `www.` from the beginning and `.git` from the end, to ensure consistent formatting. The backend will then attempt to clone the repo. If it can clone the repo, it is considered a valid URL and saved. If it can not, then it is rejected and the user is told to check their link is valid.

#### Changes to user registration
Previously, to register, a student had to submit the GitHub Repo Assignment on Canvas. Now, all they have to do is log-in to the Autograder. The Autograder will verify that they are a student in canvas, then create a new student record. Now that the student record exists in the Autograder, they will be prompted to submit a repo URL. If they log out and try to log-in without doing so, they still will be prompted to submit a repo URL.

#### Checking students don't claim another student's repo URL
When a user submits a request to change a repo URL, the new URL is checked against a new table in the database called `repo_update` containing a list of every time a user's repo URL has changed. If ANY user (besides the user whose repo URL is getting changed) has ever claimed that URL, the request to change is rejected. If a student submitted the request, they are just told to go talk to the TAs. If an admin submitted the request, they will see who has previously claimed that URL and when.

#### New backend endpoints
- `{PATCH} /api/repo` allows a student to change their repo URL. Pulls their netId from the session, and the new repo URL is passed in the request body
- `{PATCH} /api/admin/repo/:netId` allows an admin to change a student's repo URL. The student's netId is passed in via the request URL, and the new repo URL is passed in the request body
- `{GET} /api/admin/repo/history` allows an admin to get info from the new `repo_update` table. Allows table to be searched by `netId` and `repoUrl`, one or both. Parameters are passed in by a query string in the request URL

### Potential Future Work
While this feature is fully built out, there are some things that the team could reasonably want added or changed. Here are some things that came up during development that I figured should be decided later and done in later pull requests)
- While admins can view how often a student has changed their repo URL, they only can see successful changes. If they are blocked from changing their repo URL because it is/was claimed by another student, that attempt is not logged anywhere. It may or may not be beneficial to log those to see who is attempting to claim another student's repo URL. 
- Admins have no way of overriding a block. I can't see a scenario where a student should be allowed to claim the same repo URL as another student, but stranger things have happened. One could argue for the need for admins to be able to force change a student's repo URL, despite plagiarism checks.
- Currently, the page is forced to reload when an admin changes a student repo URL. To fix that, we'd need to store some data at a higher level than is currently stored.
- Run the GitHub phase at registration. This would reduce the steps a student has to take. But it could introduce additional complications depending on how the professors want things to work.