### PR TITLE
Disable the stubs of integration tests

### DIFF
--- a/src/test/java/edu/byu/cs/autograder/git/GitHelperTest.java
+++ b/src/test/java/edu/byu/cs/autograder/git/GitHelperTest.java
@@ -213,6 +213,7 @@ class GitHelperTest {
     }
 
     @Test
+    @Disabled
     void verifyCommitRequirements() {
         // Verify status preservation on repeat submissions
         // Fails when submitting new phase with same head hash
@@ -220,6 +221,7 @@ class GitHelperTest {
     }
 
     @Test
+    @Disabled
     void verifyRegularCommits() {
         // Counts commits from merges properly
         // Commits authored after the head timestamp trigger failure


### PR DESCRIPTION
In the TA meeting today, we breezed over the 200+ lines of meaningful test and pointed out the two tests which have no content. Rookie mistake; my bad.

I didn't implement these tests because they actually function as integration tests and rely on several complex data structures being configured properly.

This PR marks the tests as `@Disabled` so that they do not provide false indicators of success.