### PR TITLE
add Instant default for config

### DIFF
--- a/src/main/java/edu/byu/cs/dataAccess/sql/ConfigurationSqlDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/sql/ConfigurationSqlDao.java
@@ -68,6 +68,8 @@ public class ConfigurationSqlDao implements ConfigurationDao {
                 return type.cast(0);
             } else if (type == Boolean.class) {
                 return type.cast(false);
+            } else if (type == Instant.class) {
+                return type.cast(Instant.MAX);
             } else {
                 throw new IllegalArgumentException("Unsupported configuration type: " + type);
             }


### PR DESCRIPTION
Some silly goose _me_ forgot to set up the default value of an Instant in the Configuration SQL dao. So that meant it would crash when starting up. This fixes that bug currently on the main branch that came from #466 

Guess I need to do more thorough testing