### PR TITLE
Extracted Git Logic from UserService into GitHelper

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.UUID;
 
 public class GitHelper {
     private static final Logger LOGGER = LoggerFactory.getLogger(GitHelper.class);
@@ -89,6 +90,12 @@ public class GitHelper {
         gradingContext.observer().update("Fetching repo...");
 
         fetchRepoFromUrl(gradingContext.repoUrl(), intoDirectory);
+    }
+
+    public static File fetchRepoFromUrl(String repoUrl) throws GradingException {
+        File cloningDir = new File("./tmp" + UUID.randomUUID());
+        fetchRepoFromUrl(repoUrl, cloningDir);
+        return cloningDir;
     }
 
     //Method must be static due to the lack of GradingContext in cases where this method is required

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -49,7 +49,7 @@ public class GitHelper {
 
     public void setUp() throws GradingException {
         File stageRepo = gradingContext.stageRepo();
-        fetchRepo(gradingContext.stageRepo());
+        fetchRepo(stageRepo);
         headHash = getHeadHash(stageRepo);
     }
 

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -91,6 +91,7 @@ public class GitHelper {
         fetchRepoFromUrl(gradingContext.repoUrl(), intoDirectory);
     }
 
+    //Method must be static due to the lack of GradingContext in cases where this method is required
     public static void fetchRepoFromUrl(String repoUrl, File intoDirectory) throws GradingException {
         CloneCommand cloneCommand = Git.cloneRepository()
                 .setURI(repoUrl)

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -88,8 +88,12 @@ public class GitHelper {
     private void fetchRepo(File intoDirectory) throws GradingException {
         gradingContext.observer().update("Fetching repo...");
 
+        fetchRepoFromUrl(gradingContext.repoUrl(), intoDirectory);
+    }
+
+    public static void fetchRepoFromUrl(String repoUrl, File intoDirectory) throws GradingException {
         CloneCommand cloneCommand = Git.cloneRepository()
-                .setURI(gradingContext.repoUrl())
+                .setURI(repoUrl)
                 .setDirectory(intoDirectory);
 
         try (Git git = cloneCommand.call()) {

--- a/src/main/java/edu/byu/cs/service/UserService.java
+++ b/src/main/java/edu/byu/cs/service/UserService.java
@@ -1,27 +1,19 @@
 package edu.byu.cs.service;
 
-import edu.byu.cs.autograder.GradingException;
-import edu.byu.cs.autograder.git.GitHelper;
 import edu.byu.cs.controller.exception.BadRequestException;
 import edu.byu.cs.controller.exception.InternalServerException;
 import edu.byu.cs.controller.exception.PriorRepoClaimBlockageException;
 import edu.byu.cs.dataAccess.DaoService;
 import edu.byu.cs.dataAccess.DataAccessException;
 import edu.byu.cs.model.RepoUpdate;
-import edu.byu.cs.util.FileUtils;
 import edu.byu.cs.util.RepoUrlValidator;
-import org.eclipse.jgit.api.CloneCommand;
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.errors.GitAPIException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
-import java.util.UUID;
 
 public class UserService {
     private static final Logger LOGGER = LoggerFactory.getLogger(UserService.class);
@@ -95,17 +87,7 @@ public class UserService {
     }
 
     private static boolean isValidRepoUrl(String url) {
-        File cloningDir = new File("./tmp" + UUID.randomUUID());
-
-        try {
-            GitHelper.fetchRepoFromUrl(url, cloningDir);
-            return true;
-        } catch (GradingException e) {
-            return false;
-        }
-        finally {
-            FileUtils.removeDirectory(cloningDir);
-        }
+        return RepoUrlValidator.isValid(url);
     }
 
     /**

--- a/src/main/java/edu/byu/cs/service/UserService.java
+++ b/src/main/java/edu/byu/cs/service/UserService.java
@@ -1,5 +1,7 @@
 package edu.byu.cs.service;
 
+import edu.byu.cs.autograder.GradingException;
+import edu.byu.cs.autograder.git.GitHelper;
 import edu.byu.cs.controller.exception.BadRequestException;
 import edu.byu.cs.controller.exception.InternalServerException;
 import edu.byu.cs.controller.exception.PriorRepoClaimBlockageException;
@@ -94,16 +96,16 @@ public class UserService {
 
     private static boolean isValidRepoUrl(String url) {
         File cloningDir = new File("./tmp" + UUID.randomUUID());
-        CloneCommand cloneCommand = Git.cloneRepository().setURI(url).setDirectory(cloningDir);
 
-        try (Git git = cloneCommand.call()) {
-            LOGGER.debug("Cloning repo to {} to check repo exists", git.getRepository().getDirectory());
-        } catch (GitAPIException e) {
-            FileUtils.removeDirectory(cloningDir);
+        try {
+            GitHelper.fetchRepoFromUrl(url, cloningDir);
+            return true;
+        } catch (GradingException e) {
             return false;
         }
-        FileUtils.removeDirectory(cloningDir);
-        return true;
+        finally {
+            FileUtils.removeDirectory(cloningDir);
+        }
     }
 
     /**

--- a/src/main/java/edu/byu/cs/util/FileUtils.java
+++ b/src/main/java/edu/byu/cs/util/FileUtils.java
@@ -80,7 +80,7 @@ public class FileUtils {
      * @param action the action to perform on each file
      */
     public static void modifyDirectory(File dir, Consumer<File> action) {
-        if (!dir.exists()) {
+        if (dir == null || !dir.exists()) {
             return;
         }
 

--- a/src/main/java/edu/byu/cs/util/RepoUrlValidator.java
+++ b/src/main/java/edu/byu/cs/util/RepoUrlValidator.java
@@ -5,16 +5,28 @@ import edu.byu.cs.autograder.git.GitHelper;
 import org.eclipse.jgit.annotations.Nullable;
 
 import java.io.File;
-import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class RepoUrlValidator {
 
     public static boolean isValid(@Nullable String repoUrl) {
-        File cloningDir = new File("./tmp" + UUID.randomUUID());
+        return canClean(repoUrl) && canClone(repoUrl);
+    }
+
+    public static boolean canClean(String repoUrl) {
         try {
-            GitHelper.fetchRepoFromUrl(repoUrl, cloningDir);
+            clean(repoUrl);
+            return true;
+        } catch (GradingException e) {
+            return false;
+        }
+    }
+
+    public static boolean canClone(String repoUrl) {
+        File cloningDir = null;
+        try {
+            cloningDir = GitHelper.fetchRepoFromUrl(repoUrl);
             return true;
         } catch (GradingException e) {
             return false;

--- a/src/main/java/edu/byu/cs/util/RepoUrlValidator.java
+++ b/src/main/java/edu/byu/cs/util/RepoUrlValidator.java
@@ -30,8 +30,7 @@ public class RepoUrlValidator {
             return true;
         } catch (GradingException e) {
             return false;
-        }
-        finally {
+        } finally {
             FileUtils.removeDirectory(cloningDir);
         }
     }

--- a/src/main/java/edu/byu/cs/util/RepoUrlValidator.java
+++ b/src/main/java/edu/byu/cs/util/RepoUrlValidator.java
@@ -14,8 +14,7 @@ public class RepoUrlValidator {
     public static boolean isValid(@Nullable String repoUrl) {
         File cloningDir = new File("./tmp" + UUID.randomUUID());
         try {
-            String cleanUrl = clean(repoUrl);
-            GitHelper.fetchRepoFromUrl(cleanUrl, cloningDir);
+            GitHelper.fetchRepoFromUrl(repoUrl, cloningDir);
             return true;
         } catch (GradingException e) {
             return false;

--- a/src/main/java/edu/byu/cs/util/RepoUrlValidator.java
+++ b/src/main/java/edu/byu/cs/util/RepoUrlValidator.java
@@ -1,19 +1,27 @@
 package edu.byu.cs.util;
 
 import edu.byu.cs.autograder.GradingException;
+import edu.byu.cs.autograder.git.GitHelper;
 import org.eclipse.jgit.annotations.Nullable;
 
+import java.io.File;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class RepoUrlValidator {
 
     public static boolean isValid(@Nullable String repoUrl) {
+        File cloningDir = new File("./tmp" + UUID.randomUUID());
         try {
-            clean(repoUrl);
+            String cleanUrl = clean(repoUrl);
+            GitHelper.fetchRepoFromUrl(cleanUrl, cloningDir);
             return true;
-        } catch (InvalidRepoUrlException e) {
+        } catch (GradingException e) {
             return false;
+        }
+        finally {
+            FileUtils.removeDirectory(cloningDir);
         }
     }
 

--- a/src/main/java/edu/byu/cs/util/RepoUrlValidator.java
+++ b/src/main/java/edu/byu/cs/util/RepoUrlValidator.java
@@ -24,14 +24,12 @@ public class RepoUrlValidator {
     }
 
     public static boolean canClone(String repoUrl) {
-        File cloningDir = null;
         try {
-            cloningDir = GitHelper.fetchRepoFromUrl(repoUrl);
+            File cloningDir = GitHelper.fetchRepoFromUrl(repoUrl);
+            FileUtils.removeDirectory(cloningDir);
             return true;
         } catch (GradingException e) {
             return false;
-        } finally {
-            FileUtils.removeDirectory(cloningDir);
         }
     }
 


### PR DESCRIPTION
## Overview
Removed code duplicated from GitHelper and UserService where they would fetch a repo for different reasons but in the same manner. The code to do the repo fetching was made its own method.

RepoUrlValidator's isValid calls this method and does the minimal logic accordingly.

## Future Work
Work consolidating exception handling throughout the process, more importantly within UserService might be possible.

Closes #463
