### PR TITLE
Switch to Parameterized Tests in RepoUrlValidatorTests class #504

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-params -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
 
 
         <!-- https://mvnrepository.com/artifact/commons-cli/commons-cli -->

--- a/src/test/java/edu/byu/cs/util/RepoUrlValidatorTest.java
+++ b/src/test/java/edu/byu/cs/util/RepoUrlValidatorTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.IOException;
 
@@ -15,7 +17,7 @@ public class RepoUrlValidatorTest {
     @Test
     @Tag("cleanRepoUrl")
     @DisplayName("Should strip off trailing characters after repo name when given repo URL")
-        void should_stripOffTrailingCharactersAfterRepoName_when_givenRepoUrl() throws GradingException {
+    void should_stripOffTrailingCharactersAfterRepoName_when_givenRepoUrl() throws GradingException {
         // Should strip off characters after repo name
         String expectedUrl = "https://github.com/USERNAME/REPO_NAME";
         String[] urlVariants = {
@@ -140,60 +142,32 @@ public class RepoUrlValidatorTest {
 //        Assertions.assertEquals(originalUrl, grader.gradingContext.repoUrl());
     }
 
-    //  TODO: Convert these to @ParameterizedTest
-    @Test
+    @ParameterizedTest
     @Tag("isNotFork")
-    void isNotForkAcceptsNonForks() {
-        assertTrue(RepoUrlValidator.isNotFork("softwareconstruction240", "chess"));
+    @CsvSource({
+            "softwareconstruction240, chess, true",
+            "softwareconstruction240, chess-duplicated, true",
+            "softwareconstruction240, chess-fork, false",
+            "softwareconstruction240, invalid-repo-name, false",
+            "invalid-username, chess, false"
+    })
+    @DisplayName("Test RepoUrlValidator.isNotFork with various inputs")
+    void isNotForkTests(String username, String repoName, boolean expectedResult) {
+        assertEquals(expectedResult, RepoUrlValidator.isNotFork(username, repoName));
     }
 
-    @Test
-    @Tag("isNotFork")
-    void isNotForkAcceptsDuplicatedRepos() {
-        assertTrue(RepoUrlValidator.isNotFork("softwareconstruction240", "chess-duplicated"));
-    }
-
-    @Test
-    @Tag("isNotFork")
-    void isNotForkRejectsForks() {
-        assertFalse(RepoUrlValidator.isNotFork("softwareconstruction240", "chess-fork"));
-    }
-
-    @Test
-    @Tag("isNotFork")
-    void isNotForkRejectsInvalidRepos() {
-        assertFalse(RepoUrlValidator.isNotFork("softwareconstruction240", "invalid-repo-name"));
-    }
-
-    @Test
-    @Tag("isNotFork")
-    void isNotForkRejectsInvalidUsernames() {
-        assertFalse(RepoUrlValidator.isNotFork("invalid-username", "chess"));
-    }
-
-    // TODO: Convert to @ParameterizedTest to leverage asynchronous evaluation
-    @Test
-    void isValidRepoUrlAcceptsValidRepoUrls() {
-        String[] validRepos = {
-            "git@github.com:softwareconstruction240/chess.git",
-            "git@github.com:softwareconstruction240/chess-duplicated.git",
-            "https://github.com/softwareconstruction240/chess-duplicated.git"
-        };
-        for (var url : validRepos) {
-            assertTrue(RepoUrlValidator.isValid(url));
-        }
-    }
-
-    @Test
-    void isValidRepoUrlRejectsInvalidRepoUrls() {
-        String[] invalidRepos = {
-                "git@github.com:softwareconstruction240/chess-fork.git",
-                "git@github.com:softwareconstruction240/missing-repo-name.git",
-                "git@github.com:missing-username/chess.git",
-        };
-        for (var url : invalidRepos) {
-            assertFalse(RepoUrlValidator.isValid(url));
-        }
+    @ParameterizedTest
+    @CsvSource({
+            "git@github.com:softwareconstruction240/chess.git, true",
+            "git@github.com:softwareconstruction240/chess-duplicated.git, true",
+            "https://github.com/softwareconstruction240/chess-duplicated.git, true",
+            "git@github.com:softwareconstruction240/chess-fork.git, false",
+            "git@github.com:softwareconstruction240/missing-repo-name.git, false",
+            "git@github.com:missing-username/chess.git, false"
+    })
+    @DisplayName("Test RepoUrlValidator.isValid with various inputs")
+    void isValidRepoUrlTests(String url, boolean expectedResult) {
+        assertEquals(expectedResult, RepoUrlValidator.isValid(url));
     }
 
 }

--- a/src/test/java/edu/byu/cs/util/RepoUrlValidatorTest.java
+++ b/src/test/java/edu/byu/cs/util/RepoUrlValidatorTest.java
@@ -87,8 +87,8 @@ public class RepoUrlValidatorTest {
                 "https://github.com/valid-username-0123456789/valid-repo-name.git/",
                 "https://github.com/valid-username-0123456789/1_2_3_4_5_6_7_8_9_0.git/",
         };
-        for (String badUrl: goodUrls) {
-            assertDoesNotThrow(() -> RepoUrlValidator.clean(badUrl));
+        for (String url : goodUrls) {
+            assertDoesNotThrow(() -> RepoUrlValidator.clean(url));
         }
     }
 
@@ -123,10 +123,10 @@ public class RepoUrlValidatorTest {
                 "github.com:8080/USERNAME/REPO_NAME.git",
                 "https://github.com:443/softwareconstruction240/autograder",
         };
-        for (String badUrl : badUrls) {
+        for (String url : badUrls) {
             assertThrows(RepoUrlValidator.InvalidRepoUrlException.class,
-                    () -> RepoUrlValidator.clean(badUrl),
-                    "Did not reject input: " + badUrl);
+                    () -> RepoUrlValidator.clean(url),
+                    "Did not reject input: " + url);
         }
     }
 


### PR DESCRIPTION
## Overview
This PR refactors repetitive tests in the RepoUrlValidatorTests class by converting them to use @ParameterizedTest.

## Details
Refactored tests related to the isNotFork functionality by combining them into a single @ParameterizedTest. 
- Covered cases for valid and invalid forks.
 
Refactored tests for isValidRepoUrl by combining acceptance and rejection cases into a single @ParameterizedTest.
- Valid and invalid URL cases are now handled more compactly.

Adjusted assertions to ensure all scenarios are properly validated.
## Testing
<!-- How did you test this? 
     If you didn't do any testing, explain why -->
- [x] Added/updated unit tests
- [x] Tested edge cases
- [ ] Manual testing (if needed)
