### PR TITLE
Restore student repo edit button

### DIFF
--- a/src/main/resources/frontend/src/App.vue
+++ b/src/main/resources/frontend/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref } from 'vue'
+import { computed, onMounted, ref } from "vue";
 import { useAuthStore } from "@/stores/auth";
 import { loadUser, logoutPost } from "@/services/authService";
 import router from "@/router";
@@ -50,15 +50,14 @@ const repoEditDone = () => {
     <h1>CS 240 Autograder</h1>
     <h3>This is where you can submit your assignments and view your scores.</h3>
     <p>{{ greeting }} <a v-if="useAuthStore().isLoggedIn" @click="logOut">Logout</a></p>
-    <p @click="openRepoEditor = true" style="cursor: pointer;">{{ useAuthStore().user?.repoUrl }} <i class="fa-solid fa-pen-to-square" v-if="useAuthStore().user?.repoUrl"/></p>
+    <p @click="openRepoEditor = true" style="cursor: pointer">
+      {{ useAuthStore().user?.repoUrl }}
+      <i class="fa-solid fa-pen-to-square" v-if="useAuthStore().user?.repoUrl" />
+    </p>
     <BannerMessage />
   </header>
   <main>
-    <PopUp
-      id="repoEditorPopUp"
-      v-if="openRepoEditor"
-      @closePopUp="openRepoEditor = false"
-    >
+    <PopUp id="repoEditorPopUp" v-if="openRepoEditor" @closePopUp="openRepoEditor = false">
       <h2>Change Repo</h2>
       <RepoEditor @repoEditSuccess="repoEditDone" :user="useAuthStore().user" />
       This will not affect previous submissions.

--- a/src/main/resources/frontend/src/App.vue
+++ b/src/main/resources/frontend/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, reactive } from "vue";
+import { computed, onMounted, reactive, ref } from 'vue'
 import { useAuthStore } from "@/stores/auth";
 import { loadUser, logoutPost } from "@/services/authService";
 import router from "@/router";
@@ -36,11 +36,12 @@ onMounted(async () => {
   await useAppConfigStore().updateConfig();
 });
 
-const openRepoEditor = reactive({ value: false });
+const openRepoEditor = ref<boolean>(false);
 
 const repoEditDone = () => {
   openRepoEditor.value = false;
   loadUser();
+  location.reload();
 };
 </script>
 
@@ -49,16 +50,18 @@ const repoEditDone = () => {
     <h1>CS 240 Autograder</h1>
     <h3>This is where you can submit your assignments and view your scores.</h3>
     <p>{{ greeting }} <a v-if="useAuthStore().isLoggedIn" @click="logOut">Logout</a></p>
-    <p>{{ useAuthStore().user?.repoUrl }}</p>
+    <p @click="openRepoEditor = true" style="cursor: pointer;">{{ useAuthStore().user?.repoUrl }} <i class="fa-solid fa-pen-to-square" v-if="useAuthStore().user?.repoUrl"/></p>
     <BannerMessage />
   </header>
   <main>
     <PopUp
       id="repoEditorPopUp"
-      v-if="openRepoEditor.value"
-      @closePopUp="openRepoEditor.value = false"
+      v-if="openRepoEditor"
+      @closePopUp="openRepoEditor = false"
     >
+      <h2>Change Repo</h2>
       <RepoEditor @repoEditSuccess="repoEditDone" :user="useAuthStore().user" />
+      This will not affect previous submissions.
     </PopUp>
 
     <router-view />

--- a/src/main/resources/frontend/src/App.vue
+++ b/src/main/resources/frontend/src/App.vue
@@ -50,9 +50,7 @@ const repoEditDone = () => {
     <h1>CS 240 Autograder</h1>
     <h3>This is where you can submit your assignments and view your scores.</h3>
     <p>{{ greeting }} <a v-if="useAuthStore().isLoggedIn" @click="logOut">Logout</a></p>
-    <p v-if="useAuthStore().user?.repoUrl"
-       @click="openRepoEditor = true"
-       style="cursor: pointer">
+    <p v-if="useAuthStore().user?.repoUrl" @click="openRepoEditor = true" style="cursor: pointer">
       {{ useAuthStore().user?.repoUrl }}
       <i class="fa-solid fa-pen-to-square" />
     </p>

--- a/src/main/resources/frontend/src/App.vue
+++ b/src/main/resources/frontend/src/App.vue
@@ -50,9 +50,11 @@ const repoEditDone = () => {
     <h1>CS 240 Autograder</h1>
     <h3>This is where you can submit your assignments and view your scores.</h3>
     <p>{{ greeting }} <a v-if="useAuthStore().isLoggedIn" @click="logOut">Logout</a></p>
-    <p @click="openRepoEditor = true" style="cursor: pointer">
+    <p v-if="useAuthStore().user?.repoUrl"
+       @click="openRepoEditor = true"
+       style="cursor: pointer">
       {{ useAuthStore().user?.repoUrl }}
-      <i class="fa-solid fa-pen-to-square" v-if="useAuthStore().user?.repoUrl" />
+      <i class="fa-solid fa-pen-to-square" />
     </p>
     <BannerMessage />
   </header>


### PR DESCRIPTION
## Overview
Somehow, somewhere, the repo edit button got removed from the student view. This puts it back.

## Details
- Put button back
- Reload page upon successful repo change

## Testing
<!-- How did you test this? 
     If you didn't do any testing, explain why -->
- [ ] Added/updated unit tests
- [ ] Tested edge cases
- [X] Manual testing (if needed)
