### PR TITLE
Remove tests that require external repos

### DIFF
--- a/src/test/java/edu/byu/cs/util/RepoUrlValidatorTest.java
+++ b/src/test/java/edu/byu/cs/util/RepoUrlValidatorTest.java
@@ -146,8 +146,6 @@ public class RepoUrlValidatorTest {
     @Tag("isNotFork")
     @CsvSource({
             "softwareconstruction240, chess, true",
-            "softwareconstruction240, chess-duplicated, true",
-            "softwareconstruction240, chess-fork, false",
             "softwareconstruction240, invalid-repo-name, false",
             "invalid-username, chess, false"
     })
@@ -159,9 +157,6 @@ public class RepoUrlValidatorTest {
     @ParameterizedTest
     @CsvSource({
             "git@github.com:softwareconstruction240/chess.git, true",
-            "git@github.com:softwareconstruction240/chess-duplicated.git, true",
-            "https://github.com/softwareconstruction240/chess-duplicated.git, true",
-            "git@github.com:softwareconstruction240/chess-fork.git, false",
             "git@github.com:softwareconstruction240/missing-repo-name.git, false",
             "git@github.com:missing-username/chess.git, false"
     })


### PR DESCRIPTION
## Overview

Resolves https://github.com/softwareconstruction240/chess/issues/3, along with all the admin changes that @jerodw helped us accomplish.

**No tests in the Repo will pass until this is merged.**

## Testing
<!-- How did you test this? 
     If you didn't do any testing, explain why -->
- [x] Added/updated unit tests
- [ ] Tested edge cases
- [ ] Manual testing (if needed)

See an example of the failure message generated from the tests without this change: [Tests Run without fixes](https://github.com/softwareconstruction240/autograder/actions/runs/12816524645) 
