### PR TITLE
511 verify future holidays are configured

### DIFF
--- a/src/test/java/edu/byu/cs/autograder/score/LateDayCalculatorTest.java
+++ b/src/test/java/edu/byu/cs/autograder/score/LateDayCalculatorTest.java
@@ -78,7 +78,7 @@ class LateDayCalculatorTest {
     @Test
     void getNumDaysLateWithHolidays() {
         // Initialize with holidays
-        LateDayCalculator standardLateDayCalculator = new LateDayCalculator();
+        LateDayCalculator standardLateDayCalculator = new MockLateDayCalculator();
         standardLateDayCalculator.initializePublicHolidays(getMultilinePublicHolidaysConfiguration(), QUIET_HOLIDAY_INIT_WARNINGS);
 
         // See image: days-late-with-holidays-common
@@ -150,7 +150,7 @@ class LateDayCalculatorTest {
 
 
         // See image: days-late-with-holidays-friday-holiday-and-consecutive-holidays
-        LateDayCalculator customLateDayCalculator = new LateDayCalculator();
+        LateDayCalculator customLateDayCalculator = new MockLateDayCalculator();
         customLateDayCalculator.initializePublicHolidays("12/20/2024;12/24/2024;12/25/2024;12/31/2024;1/1/2025", QUIET_HOLIDAY_INIT_WARNINGS);
         String fridayHolidayDueDate = "2024-12-20 11:59:00 PM -07:00";
         ExpectedDaysDiff[] fridayHolidayAndConsecutiveHolidays = {
@@ -347,7 +347,7 @@ class LateDayCalculatorTest {
                 """;
     }
     private void validateExpectedHolidays(String encodedPublicHolidays) {
-        LateDayCalculator lateDayCalculator = new LateDayCalculator();
+        LateDayCalculator lateDayCalculator = new MockLateDayCalculator();
         var initializedPublicHolidays = lateDayCalculator.initializePublicHolidays(encodedPublicHolidays, QUIET_HOLIDAY_INIT_WARNINGS);
 
         Assertions.assertEquals(17, initializedPublicHolidays.size(),

--- a/src/test/java/edu/byu/cs/autograder/score/LateDayCalculatorTest.java
+++ b/src/test/java/edu/byu/cs/autograder/score/LateDayCalculatorTest.java
@@ -22,8 +22,7 @@ class LateDayCalculatorTest {
     @Test
     void getNumDaysLateWithoutHolidays() {
         // Initialize without holidays
-        LateDayCalculator lateDayCalculator = new LateDayCalculator();
-        lateDayCalculator.initializePublicHolidays();
+        LateDayCalculator lateDayCalculator = getHolidayLateDayCalculator(null);
 
         // See images: days-late-without-holidays (1&2)
         String dueDateStr = "2024-03-07 11:59:00 PM -07:00";
@@ -78,8 +77,8 @@ class LateDayCalculatorTest {
     @Test
     void getNumDaysLateWithHolidays() {
         // Initialize with holidays
-        LateDayCalculator standardLateDayCalculator = new MockLateDayCalculator();
-        standardLateDayCalculator.initializePublicHolidays(getMultilinePublicHolidaysConfiguration(), QUIET_HOLIDAY_INIT_WARNINGS);
+        LateDayCalculator standardLateDayCalculator = getHolidayLateDayCalculator(
+                getMultilinePublicHolidaysConfiguration());
 
         // See image: days-late-with-holidays-common
         String commonDueDate = "2024-03-07 11:59:00 PM -07:00";
@@ -150,8 +149,8 @@ class LateDayCalculatorTest {
 
 
         // See image: days-late-with-holidays-friday-holiday-and-consecutive-holidays
-        LateDayCalculator customLateDayCalculator = new MockLateDayCalculator();
-        customLateDayCalculator.initializePublicHolidays("12/20/2024;12/24/2024;12/25/2024;12/31/2024;1/1/2025", QUIET_HOLIDAY_INIT_WARNINGS);
+        LateDayCalculator customLateDayCalculator = getHolidayLateDayCalculator(
+                "12/20/2024;12/24/2024;12/25/2024;12/31/2024;1/1/2025");
         String fridayHolidayDueDate = "2024-12-20 11:59:00 PM -07:00";
         ExpectedDaysDiff[] fridayHolidayAndConsecutiveHolidays = {
                 // On Time
@@ -192,8 +191,8 @@ class LateDayCalculatorTest {
 
 
         // See image: days-late-with-holidays-holidays-on-weekends
-        LateDayCalculator customLateDayCalculator2 = new LateDayCalculator();
-        customLateDayCalculator2.initializePublicHolidays("09/16/2028;09/17/2028;09/18/2028;", QUIET_HOLIDAY_INIT_WARNINGS);
+        LateDayCalculator customLateDayCalculator2 = getHolidayLateDayCalculator(
+                "09/16/2028;09/17/2028;09/18/2028;");
         String holidaysOnWeekendsDueDate = "2028-09-14 02:15:00 PM -07:00";
         ExpectedDaysDiff[] holidaysOnWeekends = {
                 new ExpectedDaysDiff("2028-09-14 02:15:00 PM -07:00", 0), // Due date
@@ -211,8 +210,7 @@ class LateDayCalculatorTest {
     @Test
     void getNumDaysEarly() {
         // Initialize without holidays
-        LateDayCalculator lateDayCalculator = new LateDayCalculator();
-        lateDayCalculator.initializePublicHolidays();
+        LateDayCalculator lateDayCalculator = getHolidayLateDayCalculator(null);
 
         // See images: days-early
         String dueDateStr = "1999-11-19 11:59:00 PM -07:00";
@@ -347,7 +345,7 @@ class LateDayCalculatorTest {
                 """;
     }
     private void validateExpectedHolidays(String encodedPublicHolidays) {
-        LateDayCalculator lateDayCalculator = new MockLateDayCalculator();
+        LateDayCalculator lateDayCalculator = getHolidayLateDayCalculator(null);
         var initializedPublicHolidays = lateDayCalculator.initializePublicHolidays(encodedPublicHolidays, QUIET_HOLIDAY_INIT_WARNINGS);
 
         Assertions.assertEquals(17, initializedPublicHolidays.size(),
@@ -369,7 +367,7 @@ class LateDayCalculatorTest {
     }
 
     @Test
-    void publicHolidayStaleConfigurationDetected() {
+    void detectsPublicHolidayStaleConfiguration() {
         Assertions.assertDoesNotThrow(
                 () -> new LateDayCalculator().initializePublicHolidays(),
                 "LateDayCalculator should accept an empty list of holidays.");
@@ -379,6 +377,14 @@ class LateDayCalculatorTest {
         Assertions.assertThrows(RuntimeException.class,
                 () -> new LateDayCalculator().initializePublicHolidays("1/1/2000"),
                 "LateDayCalculator should report when holiday configuration is stale.");
+    }
+
+    private LateDayCalculator getHolidayLateDayCalculator(String encodedPublicHolidays) {
+        LateDayCalculator lateDayCalculator = new MockLateDayCalculator();
+        if (encodedPublicHolidays != null) {
+            lateDayCalculator.initializePublicHolidays(encodedPublicHolidays, QUIET_HOLIDAY_INIT_WARNINGS);
+        }
+        return lateDayCalculator;
     }
 
     private record ExpectedDaysDiff(String handInDate, int daysDiff){}

--- a/src/test/java/edu/byu/cs/autograder/score/LateDayCalculatorTest.java
+++ b/src/test/java/edu/byu/cs/autograder/score/LateDayCalculatorTest.java
@@ -370,6 +370,9 @@ class LateDayCalculatorTest {
 
     @Test
     void publicHolidayStaleConfigurationDetected() {
+        Assertions.assertDoesNotThrow(
+                () -> new LateDayCalculator().initializePublicHolidays(),
+                "LateDayCalculator should accept an empty list of holidays.");
         Assertions.assertThrows(RuntimeException.class,
                 () -> new LateDayCalculator().initializePublicHolidays(null),
                 "LateDayCalculator should throw when holidays are initialized as null. Provide empty collection instead.");

--- a/src/test/java/edu/byu/cs/autograder/score/LateDayCalculatorTest.java
+++ b/src/test/java/edu/byu/cs/autograder/score/LateDayCalculatorTest.java
@@ -368,5 +368,15 @@ class LateDayCalculatorTest {
         }
     }
 
+    @Test
+    void publicHolidayStaleConfigurationDetected() {
+        Assertions.assertThrows(RuntimeException.class,
+                () -> new LateDayCalculator().initializePublicHolidays(null),
+                "LateDayCalculator should throw when holidays are initialized as null. Provide empty collection instead.");
+        Assertions.assertThrows(RuntimeException.class,
+                () -> new LateDayCalculator().initializePublicHolidays("1/1/2000"),
+                "LateDayCalculator should report when holiday configuration is stale.");
+    }
+
     private record ExpectedDaysDiff(String handInDate, int daysDiff){}
 }

--- a/src/test/java/edu/byu/cs/autograder/score/MockLateDayCalculator.java
+++ b/src/test/java/edu/byu/cs/autograder/score/MockLateDayCalculator.java
@@ -7,6 +7,10 @@ import java.time.ZonedDateTime;
 public class MockLateDayCalculator extends LateDayCalculator {
     private final LateDayContext fixedContext;
 
+    public MockLateDayCalculator() {
+        this(0);
+    }
+
     public MockLateDayCalculator(int daysBeforeDueDate) {
         super();
         var now = ZonedDateTime.now();
@@ -16,5 +20,11 @@ public class MockLateDayCalculator extends LateDayCalculator {
     @Override
     protected LateDayContext doFetchLateDayContext(Phase phase, String netId) {
         return fixedContext;
+    }
+
+    @Override
+    protected void assertFutureHolidaysConfigured() throws RuntimeException {
+        // Disable these checks.
+        // Do not require tests to be chronologically up-to-date.
     }
 }

--- a/src/test/java/edu/byu/cs/autograder/score/MockLateDayCalculator.java
+++ b/src/test/java/edu/byu/cs/autograder/score/MockLateDayCalculator.java
@@ -12,7 +12,7 @@ public class MockLateDayCalculator extends LateDayCalculator {
     }
 
     public MockLateDayCalculator(int daysBeforeDueDate) {
-        super();
+        initializePublicHolidays(); // Initialize as blank; without reading default values
         var now = ZonedDateTime.now();
         fixedContext = new LateDayContext(now, now.minusDays(daysBeforeDueDate), 0);
     }


### PR DESCRIPTION
## Overview

Resolves #511. Inserts checks so that academic holidays can be relied on to be up to date.

## Details

This provides a code-level, hard stop detection assertion to verify that academic holiday configuration is not stale. This is a redundant layer to the one @webecke will complete in a more admin friendly manner in #510.

This change will cause errors to be thrown and refuse to perform any grading when the holidays are incorrectly configured. This should enable an admin to quickly identify the error during smoke testing at the beginning of a semester. Helpful error messages are thrown that explain the problem clearly to an admin user.

Hopefully, these checks never need to throw errors, but when they do, it will be a helpful and important reminder that will keep the system running smoothly. This is one adjustment that will hopefully make the AutoGrader easier to maintain in the future.

Test cases are included to protect against regressions of this behavior.

## Testing
<!-- How did you test this? 
     If you didn't do any testing, explain why -->
- [x] Added/updated unit tests
- [x] Tested edge cases
- [ ] Manual testing (if needed)

## Additional Notes
<!-- Add any extra context or screenshots
     Delete this section if there are none. -->
