### PR TITLE
fix endpoint testing bug that prevents server from starting correctly

### DIFF
--- a/src/main/java/edu/byu/cs/server/Server.java
+++ b/src/main/java/edu/byu/cs/server/Server.java
@@ -18,7 +18,7 @@ public class Server {
     }
 
     public int start() {
-        return start(0);
+        return start(8080);
     }
 
     public int start(int desiredPort) {

--- a/src/test/java/edu/byu/cs/server/ServerTest.java
+++ b/src/test/java/edu/byu/cs/server/ServerTest.java
@@ -75,7 +75,7 @@ class ServerTest {
     @BeforeAll
     public static void init() {
         server = new Server(mockedMockProvider);
-        int port = server.start();
+        int port = server.start(0);
         System.out.println("Started test HTTP server on " + port);
 
         serverFacade = new TestServerFacade("localhost", port);


### PR DESCRIPTION
## Overview
<!-- Give a brief overview of the changes made in this PR -->
#483 broke the way the server starts up, preventing the front end from finding the backend. This fixes it.

## Details
<!-- If you feel it is helpful, list the changes made -->

- Re-states that the backend needs to run on 8080
- Tells the test package to run on port 0, which seems to let it run

## Testing
<!-- How did you test this? 
     If you didn't do any testing, explain why -->
- [X] Added/updated unit tests
- [ ] Tested edge cases
- [X] Manual testing (if needed)

## Additional Notes
<!-- Add any extra context or screenshots
     Delete this section if there are none. -->
>[!Important]
> This is to fix a bug that prevents the proper functioning of the Autograder. It must be merged before the next deployment
