### PR TITLE
Fix bug where repo change requests failed

### DIFF
--- a/src/main/resources/frontend/src/components/RepoEditor.vue
+++ b/src/main/resources/frontend/src/components/RepoEditor.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { isPlausibleRepoUrl } from "@/utils/utils";
 import { defineEmits, reactive } from "vue";
-import { adminUpdateRepoPatch, studentUpdateRepoPatch } from "@/services/userService";
+import { adminUpdateRepo, studentUpdateRepo } from "@/services/userService";
 import type { User } from "@/types/types";
 import { useAuthStore } from "@/stores/auth";
 
@@ -25,9 +25,9 @@ const submitAndCheckRepo = async (sendEmit: (event: any) => void) => {
 
   try {
     if (useAuthStore().user?.role == "ADMIN" && user != null) {
-      await adminUpdateRepoPatch(newRepoUrl.value, user.netId);
+      await adminUpdateRepo(newRepoUrl.value, user.netId);
     } else {
-      await studentUpdateRepoPatch(newRepoUrl.value);
+      await studentUpdateRepo(newRepoUrl.value);
     }
   } catch (error) {
     if (error instanceof Error) {

--- a/src/main/resources/frontend/src/network/ServerCommunicator.ts
+++ b/src/main/resources/frontend/src/network/ServerCommunicator.ts
@@ -17,7 +17,6 @@ export const ServerCommunicator = {
   getRequest: getRequest,
   getRequestGuaranteed: getRequestGuaranteed,
   postRequest: postRequest,
-  patchRequest: patchRequest,
   doUnprocessedRequest: doUnprocessedRequest,
 };
 
@@ -118,66 +117,6 @@ function postRequest<T>(
 ): Promise<T | null> {
   return doRequest<T>("POST", endpoint, bodyObject, expectResponse);
 }
-
-/**
- * Makes a PATCH request to the specified endpoint.
- * @template T - The type of the expected response (when expectResponse is true)
- * @param {string} endpoint - The API endpoint to call
- * @param {Object | null} [bodyObject=null] - The request body object to send (will be sent as JSON)
- * @param {boolean} [expectResponse=true] - Whether to expect and parse a response
- * @returns {Promise<T | null>} Promise that resolves to:
- *   - The response data of type T when expectResponse is true
- *   - null when expectResponse is false
- * @throws {ServerError} When the request fails (meaning the server returned a code other than 2XX)
- * @throws {Error} when expectResponse is true but no response is received
- *
- * @example
- * // With response
- * const user = await patchRequest<User>('/api/users/123', { name: 'John' });
- *
- * // Without response
- * await patchRequest<void>('/api/users/123/status', { status: 'active' }, false);
- */
-function patchRequest(
-  endpoint: string,
-  bodyObject: Object | null,
-  expectResponse: false,
-): Promise<null>;
-/**
- * Makes a PATCH request to the specified endpoint.
- * @template T - The type of the expected response (when expectResponse is true)
- * @param {string} endpoint - The API endpoint to call
- * @param {Object | null} [bodyObject=null] - The request body object to send (will be sent as JSON)
- * @param {boolean} [expectResponse=true] - Whether to expect and parse a response
- * @returns {Promise<T | null>} Promise that resolves to:
- *   - The response data of type T when expectResponse is true
- *   - null when expectResponse is false
- * @throws {ServerError} When the request fails (meaning the server returned a code other than 2XX)
- * @throws {Error} when expectResponse is true but no response is received
- *
- * @example
- * // With response
- * const user = await patchRequest<User>('/api/users/123', { name: 'John' });
- *
- * // Without response
- * await patchRequest<void>('/api/users/123/status', { status: 'active' }, false);
- */
-function patchRequest<T>(
-  endpoint: string,
-  bodyObject?: Object | null,
-  expectResponse?: boolean,
-): Promise<T>;
-async function patchRequest<T>(
-  endpoint: string,
-  bodyObject: Object | null = null,
-  expectResponse: boolean = true,
-): Promise<T | null> {
-  if (expectResponse) {
-    return doRequest<T>("PATCH", endpoint, bodyObject, true);
-  }
-  return doRequest<T>("PATCH", endpoint, bodyObject, false);
-}
-
 /**
  * Internal method to make an HTTP request.
  * @template T - The type of the expected response (when expectResponse is true)

--- a/src/main/resources/frontend/src/services/userService.ts
+++ b/src/main/resources/frontend/src/services/userService.ts
@@ -8,16 +8,16 @@ export const repoHistoryGet = (netId: String): Promise<RepoUpdate[]> => {
   );
 };
 
-export const studentUpdateRepoPatch = (repoUrl: string): Promise<null> => {
-  return updateRepoPatch(repoUrl, "/api/repo");
+export const studentUpdateRepo = (repoUrl: string): Promise<null> => {
+  return updateRepoPost(repoUrl, "/api/repo");
 };
 
-export const adminUpdateRepoPatch = (repoUrl: string, netId: String): Promise<null> => {
-  return updateRepoPatch(repoUrl, "/api/admin/repo/" + netId);
+export const adminUpdateRepo = (repoUrl: string, netId: String): Promise<null> => {
+  return updateRepoPost(repoUrl, "/api/admin/repo/" + netId);
 };
 
-const updateRepoPatch = (repoUrl: string, endpoint: string): Promise<null> => {
-  return ServerCommunicator.patchRequest(
+const updateRepoPost = (repoUrl: string, endpoint: string): Promise<null> => {
+  return ServerCommunicator.postRequest(
     endpoint,
     {
       repoUrl: repoUrl,


### PR DESCRIPTION
## Overview
<!-- Give a brief overview of the changes made in this PR -->
It was discovered that on the current main branch, trying to change the repo of yourself as a student would result in a network error. This fixes that.

## Details
<!-- If you feel it is helpful, list the changes made -->

- Direct front end to call repo update endpoints as a `POST` request
- Remove unused `PATCH` request methods from `ServerCommunicator`
- Rename `UserService` methods to not reference the HTTP method used

## Testing
<!-- How did you test this? 
     If you didn't do any testing, explain why -->
- [ ] Added/updated unit tests
- [ ] Tested edge cases
- [X] Manual testing (if needed)

## Suspected Cause
When the great and late and beloved @ThanGerlek made his changes with #483 with the endpoint provider and whatnot, he changed the `/api/repo` endpoint to be a `POST` request. However, he didn't tell the front end about this change, and thus we got a 405 error.

## Future Work
<!-- Discuss things that should be done in the future, 
     or related work going on in other issues/PRs.
     Delete this section if there is none. -->
When @frozenfrank and others previously talked about making frontend tests and regression tests for the API, I understood they were needed, but couldn't be bothered. After the second such bug in a week, I am now fully convinced about the necessity of these frontend/integration tests and have moved #527 to the top of my to-do list.