### PR TITLE
Fix flakey commit amend test...

### DIFF
--- a/src/test/java/edu/byu/cs/autograder/git/GitHelperTest.java
+++ b/src/test/java/edu/byu/cs/autograder/git/GitHelperTest.java
@@ -4,6 +4,8 @@ import edu.byu.cs.analytics.CommitThreshold;
 import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.*;
 import java.io.File;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 
 class GitHelperTest {
@@ -216,16 +218,23 @@ class GitHelperTest {
     void amendedCommitsCountedOnce() {
         utils.setGradingContext(utils.generateGradingContext(3, 0, 0, 0));
         utils.evaluateTest("amended-commits-counted-once", new VerificationCheckpoint(repoContext -> {
-            utils.makeCommit(repoContext, "Change 1 (initial)", 0, 5, 10);
-            utils.makeCommit(repoContext, "Change 1 (amend 1)", 0, 5, 10);
-            utils.makeCommit(repoContext, "Change 1 (amend 2)", 0, 5, 10);
-            utils.makeCommit(repoContext, "Change 2 (initial)", 0, 4, 10);
-            utils.makeCommit(repoContext, "Change 2 (amend 1)", 0, 4, 10);
-            utils.makeCommit(repoContext, "Change 2 (amend 2)", 0, 4, 10);
-            utils.makeCommit(repoContext, "Change 3 (initial)", 0, 3, 10);
-            utils.makeCommit(repoContext, "Change 3 (amend 1)", 0, 3, 10);
-            utils.makeCommit(repoContext, "Change 3 (amend 2)", 0, 3, 10);
-            utils.makeCommit(repoContext, "Change 3 (amend 3)", 0, 3, 10);
+            Instant now = Instant.now();
+
+            Instant commitTime1 = now.minus(Duration.ofMinutes(5));
+            utils.makeCommit(repoContext, "Change 1 (initial)", commitTime1, 10, true);
+            utils.makeCommit(repoContext, "Change 1 (amend 1)", commitTime1, 10, true);
+            utils.makeCommit(repoContext, "Change 1 (amend 2)", commitTime1, 10, true);
+
+            Instant commitTime2 = now.minus(Duration.ofMinutes(4));
+            utils.makeCommit(repoContext, "Change 2 (initial)", commitTime2, 10, true);
+            utils.makeCommit(repoContext, "Change 2 (amend 1)", commitTime2, 10, true);
+            utils.makeCommit(repoContext, "Change 2 (amend 2)", commitTime2, 10, true);
+
+            Instant commitTime3 = now.minus(Duration.ofMinutes(3));
+            utils.makeCommit(repoContext, "Change 3 (initial)", commitTime3, 10, true);
+            utils.makeCommit(repoContext, "Change 3 (amend 1)", commitTime3, 10, true);
+            utils.makeCommit(repoContext, "Change 3 (amend 2)", commitTime3, 10, true);
+            utils.makeCommit(repoContext, "Change 3 (amend 3)", commitTime3, 10, true);
         }, utils.generalCommitVerificationResult(true, 3, 1, 2)));
     }
 


### PR DESCRIPTION
## Overview

Resolves an issue that causes the `GitHelperTest:amendedCommitsCountedOnce()` test to sometimes fail based on external factors (the clock). This comes in response to this surprise discovery https://github.com/softwareconstruction240/autograder/pull/534#issuecomment-2632038772.

## Discussion

'Flakey' is a strong word because the test did nearly all of the time it ran.

Root cause argument:
* Detecting an amended commit requires an exact timestamp match. 
* Git timestamps have second precision.
* Without actually using the `commit --amend` flag, the test would create multiple commits in quick succession which is effectively the same as amending commits. 
* As long as all the commits are authored in the same second, the test works.
* However, there is a non-zero chance that the span of commits would cross the boundary of a second and cause the test to fail.
* The exact probability has to do with the execution time of the machine creating the commits.
* ∴ Therefore, probability that the test fails under valid circumstances is **non-zero**.

This change leverages a different overload of `GitHelperUtils.makeCommit()` to specify an exact Instant where the commit should be authored. We compute `now()` once, and then determine the timestamps of the other commits based on subtractions from now(). This guarantees us that the commits will *always* have the timestamps we intend for them to have.

## Testing
<!-- How did you test this? 
     If you didn't do any testing, explain why -->
- [x] Added/updated unit tests
- [ ] Tested edge cases
- [x] Manual testing (if needed)

## Additional Notes

This change does not fundamentally change the way the test is approached. It only guarantees that is always works properly.
