### PR TITLE
432 intelligently evaluate history without tail hash

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/git/CommitValidation/DefaultGitVerificationStrategy.java
+++ b/src/main/java/edu/byu/cs/autograder/git/CommitValidation/DefaultGitVerificationStrategy.java
@@ -49,9 +49,6 @@ public class DefaultGitVerificationStrategy implements CommitVerificationStrateg
                 new CV(
                         commitsByDay.commitsBackdated(),
                         "Suspicious commit history. Some commits have been backdated."),
-                new CV(
-                        commitsByDay.missingTailHash(),
-                        "Missing tail hash. The previous submission commit could not be found in the repository."),
         };
         CV[] warningConditions = {
                 new CV(
@@ -65,7 +62,10 @@ public class DefaultGitVerificationStrategy implements CommitVerificationStrateg
                         commitsByDay.getErroringCommitsSet("commitTimestampsDuplicatedSubsequentOnly"),
                         "Mistaken history manipulation. Multiple commits have the exact same timestamp. Likely, commits were pushed and amended and merged together."),
                 new CV(
-                        commitsByDay.commitsInPast(),
+                        commitsByDay.missingTailHash(),
+                        "Missing tail hash. The previous submission commit could not be found in the repository."),
+                new CV(
+                        commitsByDay.commitsInPast() && !commitsByDay.missingTailHash(),
                         "Some commits excluded. Commits authored before the previous phase submission were not counted."),
         };
 

--- a/src/main/java/edu/byu/cs/autograder/git/CommitValidation/DefaultGitVerificationStrategy.java
+++ b/src/main/java/edu/byu/cs/autograder/git/CommitValidation/DefaultGitVerificationStrategy.java
@@ -66,7 +66,7 @@ public class DefaultGitVerificationStrategy implements CommitVerificationStrateg
                         "Mistaken history manipulation. Multiple commits have the exact same timestamp. Likely, commits were pushed and amended and merged together."),
                 new CV(
                         commitsByDay.commitsInPast(),
-                        "Some commits excluded. Commits authored before the previous phase hash were not counted."),
+                        "Some commits excluded. Commits authored before the previous phase submission were not counted."),
         };
 
         // Preserve the first set of messages (preserve the original warnings about amending commits)

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -322,6 +322,7 @@ public class GitHelper {
         String latestCommitHash = null;
         Repository repo = git.getRepository();
         boolean hasCandidateSubmission = false;
+        boolean missingLatestHash = false;
 
         EffectiveTimestamp effectiveTimestamp;
         try (RevWalk revWalk = new RevWalk(repo)) {
@@ -334,8 +335,10 @@ public class GitHelper {
 
                 if (latestTimestamp == null || effectiveTimestamp.timestamp.isAfter(latestTimestamp)) {
                     latestTimestamp = effectiveTimestamp.timestamp;
+                    missingLatestHash = true;
                     if (effectiveTimestamp.commitExists) {
                         latestCommitHash = submission.headHash();
+                        missingLatestHash = false;
                     }
                 }
             }
@@ -346,6 +349,11 @@ public class GitHelper {
         }
         if (latestTimestamp == null) {
             throw new GradingException("After processing a non-empty set of passing submissions, our latestTimestamp timestamp is null.");
+        }
+        if (missingLatestHash) {
+            gradingContext.observer().notifyWarning("The latest commit hash could not be found, "
+                    + " even though passing & graded submissions exist."
+                    + "This is expected if you recently nuked your repository.");
         }
 
         return new CommitThreshold(latestTimestamp, latestCommitHash);

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -322,7 +322,6 @@ public class GitHelper {
         String latestCommitHash = null;
         Repository repo = git.getRepository();
         boolean hasCandidateSubmission = false;
-        boolean missingLatestHash = false;
 
         EffectiveTimestamp effectiveTimestamp;
         try (RevWalk revWalk = new RevWalk(repo)) {
@@ -335,10 +334,8 @@ public class GitHelper {
 
                 if (latestTimestamp == null || effectiveTimestamp.timestamp.isAfter(latestTimestamp)) {
                     latestTimestamp = effectiveTimestamp.timestamp;
-                    missingLatestHash = true;
                     if (effectiveTimestamp.commitExists) {
                         latestCommitHash = submission.headHash();
-                        missingLatestHash = false;
                     }
                 }
             }
@@ -349,11 +346,6 @@ public class GitHelper {
         }
         if (latestTimestamp == null) {
             throw new GradingException("After processing a non-empty set of passing submissions, our latestTimestamp timestamp is null.");
-        }
-        if (missingLatestHash) {
-            gradingContext.observer().notifyWarning("The latest commit hash could not be found, "
-                    + " even though passing & graded submissions exist."
-                    + "This is expected if you recently nuked your repository.");
         }
 
         return new CommitThreshold(latestTimestamp, latestCommitHash);

--- a/src/test/java/edu/byu/cs/autograder/git/GitHelperTest.java
+++ b/src/test/java/edu/byu/cs/autograder/git/GitHelperTest.java
@@ -261,20 +261,21 @@ class GitHelperTest {
         utils.evaluateTest("missing-tail-commit", List.of(
                 new VerificationCheckpoint(
                     repoContext -> {
-                        utils.makeCommit(repoContext, "Change 1", 24, 39, 20);
+                        utils.makeCommit(repoContext, "Change 1", 1, 9, 20);
                     },
                     utils.generalCommitVerificationResult(true, 1, 1)),
                 new VerificationCheckpoint(
                     repoContext -> {
-                        utils.makeCommit(repoContext, "Change 2", 23, 38, 10);
+                        utils.makeCommit(repoContext, "Change 2", 0, 3, 10);
 
                         // NOTE: I tried putting in an *obviously* incorrect head hash for testing, but it JGit rejected
                         // it with an InvalidObjectIdException. Apparently the ObjectIds cannot be any alphanumeric string.
-                        utils.setPrevSubmissionHeadHash("f6fbf36bd4f932177df1bc70fbd5a32da288c6d7"); // Commit doesn't exist
+                        utils.setPrevSubmissionHeadHash(null); // Commit wasn't found during processing
+                        utils.setPrevSubmissionTimestamp(Instant.now().minus(Duration.ofMinutes(30))); // Submitted between the two phases
                     },
-                    // Since the tail hash doesn't exist, it will evaluate the entire repository resulting in 2 commits on two days.
+                    // Since the tail hash doesn't exist, it will evaluate the entire repository. On the resulting in 2 commits on two days.
                     // It will be flagged as potentially incorrect and require manual intervention.
-                    utils.generalCommitVerificationResult(false, 2, 2, true))
+                    utils.generalCommitVerificationResult(true, 1, 1, true))
         ));
     }
 

--- a/src/test/java/edu/byu/cs/autograder/git/GitHelperTest.java
+++ b/src/test/java/edu/byu/cs/autograder/git/GitHelperTest.java
@@ -258,6 +258,7 @@ class GitHelperTest {
     @Test
     void passoffMissingTailHash() {
         utils.setGradingContext(utils.generateGradingContext(1, 1, 10,  1));
+        Collection<String> submissionWarnings = List.of("Missing tail hash", "Additional warning");
         utils.evaluateTest("missing-tail-commit", List.of(
                 new VerificationCheckpoint(
                     repoContext -> {
@@ -270,12 +271,12 @@ class GitHelperTest {
 
                         // NOTE: I tried putting in an *obviously* incorrect head hash for testing, but it JGit rejected
                         // it with an InvalidObjectIdException. Apparently the ObjectIds cannot be any alphanumeric string.
-                        utils.setPrevSubmissionHeadHash(null); // Commit wasn't found during processing
+                        utils.setPrevSubmissionHeadHash("f6fbf36bd4f932177df1bc70fbd5a32da288c6d7"); // Commit doesn't exist
                         utils.setPrevSubmissionTimestamp(Instant.now().minus(Duration.ofMinutes(30))); // Submitted between the two phases
                     },
-                    // Since the tail hash doesn't exist, it will evaluate the entire repository. On the resulting in 2 commits on two days.
-                    // It will be flagged as potentially incorrect and require manual intervention.
-                    utils.generalCommitVerificationResult(true, 1, 1, true))
+                    // Since the tail hash doesn't exist, it will evaluate the entire repository.
+                    // Only the commits since the last pass-off are counted, and the submission will not be blocked.
+                    utils.generalCommitVerificationResult(true, 1, 1, 1, true, submissionWarnings))
         ));
     }
 


### PR DESCRIPTION
## Overview

Upgrades Commit Verification internals to produce an accurate result even when student nuke their repos before Phase 1. Resolves #432.

## Details

Although I thought I would need to make some minor modifications to the algorithm, in the end, it appears that we only needed a configuration-type change in `DefaultGitVerificationStrategy`. I see that as a benefit of well designed code!

This PR does update test cases to function with the new paradigm.

## Testing
<!-- How did you test this? 
     If you didn't do any testing, explain why -->
- [x] Added/updated unit tests
- [x] Tested edge cases
- [ ] Manual testing (if needed)

## Future Work
<!-- Discuss things that should be done in the future, 
     or related work going on in other issues/PRs.
     Delete this section if there is none. -->

While working on this PR, I remembered that the `git` tests work at a low level and never test the integration of `Submission` handling with the git commits together. Future developers could add higher-level, integration-type tests which properly exercise and demonstrate correct behavior of the entire system.

## Additional Notes

At this point, I do not expect any more students to have this issue this semester, but someone will probably surprise me. At any rate, we should manually test this with a legit repo and then merge it in so we don't repeat the issues against next semester.
