### PR TITLE
Provide commit results in submission

### DIFF
--- a/src/main/java/edu/byu/cs/analytics/CommitAnalytics.java
+++ b/src/main/java/edu/byu/cs/analytics/CommitAnalytics.java
@@ -73,7 +73,7 @@ public class CommitAnalytics {
         Map<String, Integer> days = new TreeMap<>();
         int singleParentCommits = 0;
         int mergeCommits = 0;
-        List<Integer> changesPerCommit = new LinkedList<>();
+        Map<String, Integer> lineChangesPerCommit = new HashMap<>();
         Map<String, List<String>> erroringCommits = new HashMap<>();
         boolean commitsInOrder = true;
         boolean commitsInFuture = false;
@@ -91,6 +91,7 @@ public class CommitAnalytics {
         // Iteration helpers
         CommitTimestamps commitTimes;
         String commitHash;
+        int numLineChanges;
         for (RevCommit rc : commitsBetweenBounds.commits()) {
             commitHash = rc.getName();
             if (excludeCommits.contains(commitHash)) {
@@ -132,7 +133,8 @@ public class CommitAnalytics {
             }
 
             // Count changes in each commit
-            changesPerCommit.add(getNumChangesInCommit(diffFormatter, rc));
+            numLineChanges = getNumChangesInCommit(diffFormatter, rc);
+            lineChangesPerCommit.put(commitHash, numLineChanges);
             groupCommitsByKey(commitsByTimestamp, commitTimes.seconds, commitHash);
 
             // Add the commit to results
@@ -150,7 +152,7 @@ public class CommitAnalytics {
         }
 
         return new CommitsByDay(
-                days, changesPerCommit, erroringCommits,
+                days, lineChangesPerCommit, erroringCommits,
                 singleParentCommits, mergeCommits,
                 commitsInOrder, commitsInFuture, commitsInPast, commitsBackdated, commitsWithSameTimestamp, missingTailHash,
                 lowerBound, upperBound);

--- a/src/main/java/edu/byu/cs/analytics/CommitsByDay.java
+++ b/src/main/java/edu/byu/cs/analytics/CommitsByDay.java
@@ -30,6 +30,7 @@ import java.util.*;
  */
 public record CommitsByDay(
         Map<String, Integer> dayMap,
+        // TODO: Save a direct relationship between commits and num changes
         List<Integer> changesPerCommit,
         Map<String, List<String>> erroringCommits,
         int totalCommits,

--- a/src/main/java/edu/byu/cs/analytics/CommitsByDay.java
+++ b/src/main/java/edu/byu/cs/analytics/CommitsByDay.java
@@ -11,7 +11,8 @@ import java.util.*;
  *
  * @param dayMap Represents each of the calendar days,
  *               with the number of commits on that day.
- * @param changesPerCommit One entry for each commit processed, representing the number of lines changed in the commit.
+ * @param lineChangesPerCommit One entry for each commit processed, representing the full commit hash
+ *                            and the number of lines changed in the commit.
  * @param erroringCommits Reports commit hashes that triggered any of the failure conditions,
  *                        grouped by a natural key into the kinds of conditions that they failed.
  *                        This will be empty when there are no erroring commits.
@@ -30,8 +31,7 @@ import java.util.*;
  */
 public record CommitsByDay(
         Map<String, Integer> dayMap,
-        // TODO: Save a direct relationship between commits and num changes
-        List<Integer> changesPerCommit,
+        Map<String, Integer> lineChangesPerCommit,
         Map<String, List<String>> erroringCommits,
         int totalCommits,
         int mergeCommits,

--- a/src/main/java/edu/byu/cs/autograder/Grader.java
+++ b/src/main/java/edu/byu/cs/autograder/Grader.java
@@ -4,6 +4,7 @@ import edu.byu.cs.autograder.compile.CompileHelper;
 import edu.byu.cs.autograder.database.DatabaseHelper;
 import edu.byu.cs.autograder.git.CommitValidation.DefaultGitVerificationStrategy;
 import edu.byu.cs.autograder.git.CommitVerificationConfig;
+import edu.byu.cs.autograder.git.CommitVerificationReport;
 import edu.byu.cs.autograder.git.CommitVerificationResult;
 import edu.byu.cs.autograder.git.GitHelper;
 import edu.byu.cs.autograder.score.LateDayCalculator;
@@ -87,11 +88,11 @@ public class Grader implements Runnable {
 
     public void run() {
         observer.notifyStarted();
-        CommitVerificationResult commitVerificationResult = null;
+        CommitVerificationReport commitVerificationReport = null;
         try {
             // FIXME: remove this sleep. currently the grader is too quick for the client to keep up
             Thread.sleep(1000);
-            commitVerificationResult = gitHelper.setUpAndVerifyHistory();
+            commitVerificationReport = gitHelper.setUpAndVerifyHistory();
             dbHelper.setUp();
             if (RUN_COMPILATION && gradingContext.phase() != Phase.GitHub) {
                 compileHelper.compile();
@@ -99,15 +100,15 @@ public class Grader implements Runnable {
             }
 
             RubricConfig rubricConfig = DaoService.getRubricConfigDao().getRubricConfig(gradingContext.phase());
-            Rubric rubric = evaluateProject(RUN_COMPILATION ? rubricConfig : null, commitVerificationResult);
+            Rubric rubric = evaluateProject(RUN_COMPILATION ? rubricConfig : null, commitVerificationReport.result());
 
-            Submission submission = scorer.score(rubric, commitVerificationResult);
+            Submission submission = scorer.score(rubric, commitVerificationReport);
             DaoService.getSubmissionDao().insertSubmission(submission);
 
             observer.notifyDone(submission);
         } catch (Exception e) {
             GradingException ge = e instanceof GradingException ? (GradingException) e : new GradingException(e);
-            handleException(ge, commitVerificationResult);
+            handleException(ge, commitVerificationReport);
             LOGGER.error("Error running grader for user {} and repository {}", gradingContext.netId(),
                     gradingContext.repoUrl(), e);
         } finally {
@@ -144,7 +145,7 @@ public class Grader implements Runnable {
         return new Rubric(rubricItems, false, "");
     }
 
-    private void handleException(GradingException ge, CommitVerificationResult cvr) {
+    private void handleException(GradingException ge, CommitVerificationReport cvr) {
         if(cvr == null) {
             observer.notifyError(ge.getMessage());
             return;

--- a/src/main/java/edu/byu/cs/autograder/git/CommitValidation/CommitVerificationContext.java
+++ b/src/main/java/edu/byu/cs/autograder/git/CommitValidation/CommitVerificationContext.java
@@ -3,6 +3,15 @@ package edu.byu.cs.autograder.git.CommitValidation;
 import edu.byu.cs.analytics.CommitsByDay;
 import edu.byu.cs.autograder.git.CommitVerificationConfig;
 
+/**
+ * Represents the context used to evaluate git commits.
+ *
+ * @param config
+ * @param commitsByDay
+ * @param numCommits
+ * @param daysWithCommits
+ * @param significantCommits
+ */
 public record CommitVerificationContext(
         CommitVerificationConfig config,
         CommitsByDay commitsByDay,
@@ -10,4 +19,7 @@ public record CommitVerificationContext(
         int daysWithCommits,
         long significantCommits
 ) {
+    public CommitVerificationContext(CommitVerificationConfig config) {
+        this(config, null, 0, 0, 0);
+    }
 }

--- a/src/main/java/edu/byu/cs/autograder/git/CommitVerificationReport.java
+++ b/src/main/java/edu/byu/cs/autograder/git/CommitVerificationReport.java
@@ -1,0 +1,18 @@
+package edu.byu.cs.autograder.git;
+
+import edu.byu.cs.autograder.git.CommitValidation.CommitVerificationContext;
+import org.eclipse.jgit.annotations.NonNull;
+import org.eclipse.jgit.annotations.Nullable;
+
+/**
+ * Holds both the context and the result used to arrive at a decision.
+ *
+ * @param context The {@link CommitVerificationContext} used to arrive at a decision.
+ *                Null represents a skipped evaluation where commits were not actually evaluated.
+ * @param result The {@link CommitVerificationResult} containing the result.
+ *               Never null.
+ */
+public record CommitVerificationReport(
+        @Nullable CommitVerificationContext context,
+        @NonNull CommitVerificationResult result
+) { }

--- a/src/main/java/edu/byu/cs/autograder/git/CommitVerificationResult.java
+++ b/src/main/java/edu/byu/cs/autograder/git/CommitVerificationResult.java
@@ -1,5 +1,6 @@
 package edu.byu.cs.autograder.git;
 
+import edu.byu.cs.autograder.git.CommitValidation.CommitVerificationContext;
 import org.eclipse.jgit.annotations.NonNull;
 import org.eclipse.jgit.annotations.Nullable;
 
@@ -42,4 +43,8 @@ public record CommitVerificationResult(
         Instant maxAllowedThreshold,
         @NonNull String headHash,
         String tailHash
-) { }
+) {
+    public CommitVerificationReport toReport(CommitVerificationContext context) {
+        return new CommitVerificationReport(context, this);
+    }
+}

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -51,7 +51,7 @@ public class GitHelper {
     }
 
     // ## Entry Point ##
-    public CommitVerificationResult setUpAndVerifyHistory() throws GradingException {
+    public CommitVerificationReport setUpAndVerifyHistory() throws GradingException {
         setUp();
         return verifyCommitHistory();
     }
@@ -62,7 +62,7 @@ public class GitHelper {
         headHash = getHeadHash(stageRepo);
     }
 
-    public CommitVerificationResult verifyCommitHistory() {
+    public CommitVerificationReport verifyCommitHistory() {
         if (headHash == null) {
             throw new RuntimeException("Cannot verifyCommitHistory before headHash has been populated. Call setUp() first.");
         }
@@ -70,16 +70,17 @@ public class GitHelper {
         gradingContext.observer().update("Verifying commits...");
 
         try {
-            CommitVerificationResult result = shouldVerifyCommits() ?
+            CommitVerificationReport report = shouldVerifyCommits() ?
                     verifyCommitRequirements(gradingContext.stageRepo()) :
                     skipCommitVerification(true, headHash, null);
 
+            CommitVerificationResult result = report.result();
             if (result.warningMessages() != null) {
                 var observer = gradingContext.observer();
                 result.warningMessages().forEach(observer::notifyWarning);
             }
 
-            return result;
+            return report;
         } catch (GradingException e) {
             // Grading can continue, we'll just alert them of the error.
             String errorStr = "Internally failed to evaluate commit history: " + e.getMessage();
@@ -148,11 +149,11 @@ public class GitHelper {
     }
 
     // Early decisions
-    private CommitVerificationResult skipCommitVerification(boolean verified, File stageRepo) throws GradingException {
+    private CommitVerificationReport skipCommitVerification(boolean verified, File stageRepo) throws GradingException {
         String headHash = getHeadHash(stageRepo);
         return skipCommitVerification(verified, headHash, null);
     }
-    private CommitVerificationResult skipCommitVerification(boolean verified, @NonNull String headHash, String failureMessage) {
+    private CommitVerificationReport skipCommitVerification(boolean verified, @NonNull String headHash, String failureMessage) {
         if (headHash == null) {
             throw new IllegalArgumentException("Head hash cannot be null");
         }
@@ -162,7 +163,7 @@ public class GitHelper {
                 0, 0, 0, false, 0, failureMessage, null,
                 Instant.MIN, Instant.MAX,
                 headHash, null
-        );
+        ).toReport(null);
     }
 
     // Decision Logic
@@ -171,10 +172,10 @@ public class GitHelper {
      * Decides whether a git repo passes the requirements and returns the evaluation results.
      *
      * @param stageRepo A {@link File} pointing to a directory on the local machine with the repo to evaluate.
-     * @return A {@link CommitVerificationResult} with the results.
+     * @return A {@link CommitVerificationReport} with the results.
      * @throws GradingException When certain assumptions are not met.
      */
-    CommitVerificationResult verifyCommitRequirements(File stageRepo) throws GradingException {
+    CommitVerificationReport verifyCommitRequirements(File stageRepo) throws GradingException {
         try {
             var potentialResult = preserveOriginalVerification();
             if (potentialResult != null) {
@@ -199,9 +200,9 @@ public class GitHelper {
      * Performs the explicit remembering of the authorization of previous phases.
      *
      * @return Null if no decision is made. If a previous submission exists for the given phase,
-     * returns a special `CommitVerificationResult` that represents the state.
+     * returns a special {@link CommitVerificationReport} that represents the state.
      */
-    private CommitVerificationResult preserveOriginalVerification() throws DataAccessException {
+    private CommitVerificationReport preserveOriginalVerification() throws DataAccessException {
         Submission firstPassingSubmission = getFirstPassingSubmission();
         if (firstPassingSubmission == null || firstPassingSubmission.verifiedStatus() == null) {
             return null;
@@ -215,7 +216,7 @@ public class GitHelper {
                 verified, true,
                 0, 0, 0, false, originalPenaltyPct, failureMessage, null,
                 null, null, headHash, null
-        );
+        ).toReport(null);
     }
 
     private static String generateFailureMessage(boolean verified, Submission firstPassingSubmission) {
@@ -237,9 +238,9 @@ public class GitHelper {
     /**
      * Analyzes the commits in the given directory within the bounds provided.
      *
-     * @return {@link CommitVerificationResult} Representing the verification results
+     * @return {@link CommitVerificationReport} Representing the verification results and context used to generate it
      */
-    CommitVerificationResult verifyRegularCommits(
+    CommitVerificationReport verifyRegularCommits(
             Git git, CommitThreshold lowerThreshold, CommitThreshold upperThreshold)
             throws GitAPIException, IOException, DataAccessException, GradingException {
 
@@ -275,7 +276,7 @@ public class GitHelper {
             String errorMessage = errorResults == null ? "" : String.join("\n", errorResults.messages());
             boolean hasErrors = errorResults != null && !errorResults.isEmpty();
 
-            return new CommitVerificationResult(
+            var result = new CommitVerificationResult(
                     !hasErrors,
                     false,
                     numCommits,
@@ -290,6 +291,7 @@ public class GitHelper {
                     commitsByDay.upperThreshold().commitHash(),
                     commitsByDay.lowerThreshold().commitHash()
             );
+            return new CommitVerificationReport(context, result);
         } while (true);
 
     }

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -253,7 +253,8 @@ public class GitHelper {
 
             int numCommits = commitsByDay.totalCommits();
             int daysWithCommits = commitsByDay.dayMap().size();
-            long significantCommits = commitsByDay.changesPerCommit().stream().filter(i -> i >= minimumLinesChangedPerCommit).count();
+            long significantCommits = commitsByDay.lineChangesPerCommit().values()
+                    .stream().filter(i -> i >= minimumLinesChangedPerCommit).count();
 
             CommitVerificationContext context = new CommitVerificationContext(
                     gradingContext.verificationConfig(),

--- a/src/main/java/edu/byu/cs/autograder/score/Scorer.java
+++ b/src/main/java/edu/byu/cs/autograder/score/Scorer.java
@@ -2,6 +2,7 @@ package edu.byu.cs.autograder.score;
 
 import edu.byu.cs.autograder.GradingContext;
 import edu.byu.cs.autograder.GradingException;
+import edu.byu.cs.autograder.git.CommitVerificationReport;
 import edu.byu.cs.autograder.git.CommitVerificationResult;
 import edu.byu.cs.canvas.CanvasException;
 import edu.byu.cs.canvas.CanvasService;
@@ -59,19 +60,19 @@ public class Scorer {
      * When appropriate, it will save the score the grade-book,
      * but it always returns a {@link Submission} that can be
      * @param rubric A freshly generated {@link Rubric} from the grading system.
-     * @param commitVerificationResult The associated {@link CommitVerificationResult} from the verification system.
+     * @param commitVerificationReport The report from the verification system.
      * @return A {@link Submission} ready to save in the database.
      * @throws GradingException When pre-conditions are not met.
      * @throws DataAccessException When the database cannot be accessed.
      */
-    public Submission score(Rubric rubric, CommitVerificationResult commitVerificationResult) throws GradingException, DataAccessException {
+    public Submission score(Rubric rubric, CommitVerificationReport commitVerificationReport) throws GradingException, DataAccessException {
         gradingContext.observer().update("Grading...");
 
         rubric = transformRubric(rubric);
 
         // Exit early when the score isn't important
         if (gradingContext.admin() || !PhaseUtils.isPhaseGraded(gradingContext.phase())) {
-            return generateSubmissionObject(rubric, commitVerificationResult, 0, getScores(rubric), "");
+            return generateSubmissionObject(rubric, commitVerificationReport, 0, getScores(rubric), "");
         }
 
         int daysLate = lateDayCalculator.calculateLateDays(gradingContext.phase(), gradingContext.netId());
@@ -80,12 +81,15 @@ public class Scorer {
 
         // Validate several conditions before submitting to the grade-book
         if (!rubric.passed()) {
-            return generateSubmissionObject(rubric, commitVerificationResult, daysLate, scores, "");
-        } else if (!commitVerificationResult.verified()) {
-            return generateSubmissionObject(rubric, commitVerificationResult, daysLate, scores, commitVerificationResult.failureMessage());
+            return generateSubmissionObject(rubric, commitVerificationReport, daysLate, scores, "");
+        }
+
+        CommitVerificationResult commitVerificationResult = commitVerificationReport.result();
+        if (!commitVerificationResult.verified()) {
+            return generateSubmissionObject(rubric, commitVerificationReport, daysLate, scores, commitVerificationResult.failureMessage());
         } else {
             // The student (may) receive a score in canvas!
-            return successfullyProcessSubmission(rubric, commitVerificationResult, daysLate, scores);
+            return successfullyProcessSubmission(rubric, commitVerificationReport, daysLate, scores);
         }
     }
 
@@ -111,7 +115,7 @@ public class Scorer {
      * Calling this method constitutes a successful, verified submission that will be submitted to canvas.
      *
      * @param rubric                   The rubric for the submission
-     * @param commitVerificationResult Required when originally creating a submission.
+     * @param commitVerificationReport Required when originally creating a submission.
      *                                 Can be null when sending scores to Canvas; this will disable
      *                                 any automatic point deductions for verification, and also result in
      *                                 <code>null</code> being returned instead of a {@link Submission}.
@@ -122,16 +126,17 @@ public class Scorer {
      * @throws DataAccessException When the database can't be reached.
      * @throws GradingException    When other conditions fail.
      */
-    private Submission successfullyProcessSubmission(Rubric rubric, CommitVerificationResult commitVerificationResult,
+    private Submission successfullyProcessSubmission(Rubric rubric, CommitVerificationReport commitVerificationReport,
                                                      int daysLate, ScorePair scores) throws DataAccessException, GradingException {
 
         if (!ApplicationProperties.useCanvas()) {
-            return generateSubmissionObject(rubric, commitVerificationResult, daysLate, scores,
+            return generateSubmissionObject(rubric, commitVerificationReport, daysLate, scores,
                     "Would have attempted grade-book submission, but skipped due to application properties.");
         }
 
+        CommitVerificationResult commitVerificationResult = commitVerificationReport.result();
         AssessmentSubmittalRemnants submittalRemnants = attemptSendToCanvas(rubric, commitVerificationResult);
-        return generateSubmissionObject(rubric, commitVerificationResult, daysLate, scores, submittalRemnants.notes);
+        return generateSubmissionObject(rubric, commitVerificationReport, daysLate, scores, submittalRemnants.notes);
     }
 
     /**
@@ -413,7 +418,7 @@ public class Scorer {
      * Other objects are constructed independently for that purpose.
      *
      * @param rubric A fully transformed and populated Rubric.
-     * @param commitVerificationResult Results from the commit verification system.
+     * @param commitVerificationReport Results from the commit verification system.
      *                                 If this value is null, the function will return null.
      * @param numDaysLate The number of days late this submission was handed-in.
      *                    For note generating purposes only; this is not used to
@@ -422,13 +427,14 @@ public class Scorer {
      * @param notes Any notes that are associated with the submission.
      *              More comments may be added to this string while preparing the Submission.
      */
-    public Submission generateSubmissionObject(Rubric rubric, CommitVerificationResult commitVerificationResult,
+    public Submission generateSubmissionObject(Rubric rubric, CommitVerificationReport commitVerificationReport,
                                                 int numDaysLate, ScorePair scores, String notes)
             throws GradingException, DataAccessException {
-        if (commitVerificationResult == null) {
+        if (commitVerificationReport == null) {
             return null; // This is allowed.
         }
 
+        CommitVerificationResult commitVerificationResult = commitVerificationReport.result();
         String headHash = commitVerificationResult.headHash();
         String netId = gradingContext.netId();
 
@@ -462,7 +468,7 @@ public class Scorer {
                 rubric,
                 gradingContext.admin(),
                 verifiedStatus,
-                null, // TODO: Hydrate this value with actual data
+                commitVerificationReport.context(),
                 commitVerificationResult,
                 null
         );

--- a/src/main/java/edu/byu/cs/autograder/score/Scorer.java
+++ b/src/main/java/edu/byu/cs/autograder/score/Scorer.java
@@ -462,6 +462,8 @@ public class Scorer {
                 rubric,
                 gradingContext.admin(),
                 verifiedStatus,
+                null, // TODO: Hydrate this value with actual data
+                commitVerificationResult,
                 null
         );
     }

--- a/src/main/java/edu/byu/cs/dataAccess/memory/SubmissionMemoryDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/memory/SubmissionMemoryDao.java
@@ -147,6 +147,8 @@ public class SubmissionMemoryDao implements SubmissionDao {
                     submission.rubric(),
                     submission.admin(),
                     Submission.VerifiedStatus.ApprovedManually,     // Changed
+                    submission.commitContext(),
+                    submission.commitResult(),
                     scoreVerification                               // Changed
             ));
             return; // We found it!

--- a/src/main/java/edu/byu/cs/dataAccess/memory/SubmissionMemoryDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/memory/SubmissionMemoryDao.java
@@ -134,23 +134,8 @@ public class SubmissionMemoryDao implements SubmissionDao {
             if (!targetSubmission.equals(submission)) continue;
 
             iterator.remove();
-            submissions.add(new Submission(
-                    submission.netId(),
-                    submission.repoUrl(),
-                    submission.headHash(),
-                    submission.timestamp(),
-                    submission.phase(),
-                    submission.passed(),
-                    newScore,                                       // Changed
-                    submission.rawScore(),
-                    submission.notes(),
-                    submission.rubric(),
-                    submission.admin(),
-                    Submission.VerifiedStatus.ApprovedManually,     // Changed
-                    submission.commitContext(),
-                    submission.commitResult(),
-                    scoreVerification                               // Changed
-            ));
+            submissions.add(submission.updateApproval(
+                    newScore, Submission.VerifiedStatus.ApprovedManually, scoreVerification));
             return; // We found it!
         }
 

--- a/src/main/java/edu/byu/cs/dataAccess/sql/SqlDb.java
+++ b/src/main/java/edu/byu/cs/dataAccess/sql/SqlDb.java
@@ -58,6 +58,8 @@ public class SqlDb {
                                 `notes` TEXT,
                                 `rubric` JSON,
                                 `verified_status` VARCHAR(30),
+                                `commit_context` JSON,
+                                `commit_result` JSON,
                                 `verification` JSON,
                                 `admin` BOOL NOT NULL,
                                 PRIMARY KEY (`id`),

--- a/src/main/java/edu/byu/cs/dataAccess/sql/SubmissionSqlDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/sql/SubmissionSqlDao.java
@@ -63,14 +63,15 @@ public class SubmissionSqlDao implements SubmissionDao {
         String commitResultJson = rs.getString("commit_result");
         String verificationJson = rs.getString("verification");
 
-        Submission.VerifiedStatus verifiedStatus = verifiedStatusStr == null ? null :
+        Submission.VerifiedStatus verifiedStatus =
+                verifiedStatusStr == null ? null :
                 Submission.VerifiedStatus.valueOf(verifiedStatusStr);
-        CommitVerificationContext commitContext = commitContextJson == null ? null :
-                Serializer.deserialize(commitContextJson, CommitVerificationContext.class);
-        CommitVerificationResult commitResult = commitResultJson == null ? null :
-                Serializer.deserialize(commitContextJson, CommitVerificationResult.class);
-        Submission.ScoreVerification scoreVerification = verificationJson == null ? null :
-                Serializer.deserialize(verificationJson, Submission.ScoreVerification.class);
+        CommitVerificationContext commitContext =
+                Serializer.deserializeSafely(commitContextJson, CommitVerificationContext.class);
+        CommitVerificationResult commitResult =
+                Serializer.deserializeSafely(commitResultJson, CommitVerificationResult.class);
+        Submission.ScoreVerification scoreVerification =
+                Serializer.deserializeSafely(verificationJson, Submission.ScoreVerification.class);
 
         return new Submission(
                 netId, repoUrl, headHash, timestamp, phase,

--- a/src/main/java/edu/byu/cs/dataAccess/sql/SubmissionSqlDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/sql/SubmissionSqlDao.java
@@ -1,5 +1,7 @@
 package edu.byu.cs.dataAccess.sql;
 
+import edu.byu.cs.autograder.git.CommitValidation.CommitVerificationContext;
+import edu.byu.cs.autograder.git.CommitVerificationResult;
 import edu.byu.cs.dataAccess.DataAccessException;
 import edu.byu.cs.dataAccess.ItemNotFoundException;
 import edu.byu.cs.dataAccess.SubmissionDao;
@@ -37,6 +39,8 @@ public class SubmissionSqlDao implements SubmissionDao {
             new ColumnDefinition<Submission>("rubric", s -> Serializer.serialize(s.rubric())),
             new ColumnDefinition<Submission>("admin", Submission::admin),
             new ColumnDefinition<Submission>("verified_status", Submission::serializeVerifiedStatus),
+            new ColumnDefinition<Submission>("commit_context", Submission::serializeCommitContext),
+            new ColumnDefinition<Submission>("commit_result", Submission::serializeCommitResult),
             new ColumnDefinition<Submission>("verification", Submission::serializeScoreVerification)
     };
 
@@ -54,16 +58,23 @@ public class SubmissionSqlDao implements SubmissionDao {
         Boolean admin = rs.getBoolean("admin");
 
         String verifiedStatusStr = rs.getString("verified_status");
+        String commitContextJson = rs.getString("commit_context");
+        String commitResultJson = rs.getString("commit_result");
+        String verificationJson = rs.getString("verification");
+
         Submission.VerifiedStatus verifiedStatus = verifiedStatusStr == null ? null :
                 Submission.VerifiedStatus.valueOf(verifiedStatusStr);
-        String verificationJson = rs.getString("verification");
+        CommitVerificationContext commitContext = commitContextJson == null ? null :
+                Serializer.deserialize(commitContextJson, CommitVerificationContext.class);
+        CommitVerificationResult commitResult = commitResultJson == null ? null :
+                Serializer.deserialize(commitContextJson, CommitVerificationResult.class);
         Submission.ScoreVerification scoreVerification = verificationJson == null ? null :
                 Serializer.deserialize(verificationJson, Submission.ScoreVerification.class);
 
         return new Submission(
                 netId, repoUrl, headHash, timestamp, phase,
                 passed, score, rawScore, notes, rubric,
-                admin, verifiedStatus, scoreVerification);
+                admin, verifiedStatus, commitContext, commitResult, scoreVerification);
     }
 
     private final SqlReader<Submission> sqlReader = new SqlReader<Submission>(

--- a/src/main/java/edu/byu/cs/dataAccess/sql/helpers/SqlReader.java
+++ b/src/main/java/edu/byu/cs/dataAccess/sql/helpers/SqlReader.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import java.sql.*;
 import java.util.*;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import static java.sql.Types.NULL;
 
@@ -21,7 +22,7 @@ public class SqlReader <T> {
     private final String tableName;
     /** Represents all the columns in the table. */
     private final ColumnDefinition<T>[] columnDefinitions;
-    private final String[] allColumnNames;
+    public final String[] allColumnNames;
     private final ItemBuilder<T> itemBuilder;
 
     private final String allColumnNamesStmt;
@@ -73,11 +74,18 @@ public class SqlReader <T> {
         this.itemBuilder = itemBuilder;
 
         // Several pre-constructed statement fragments
-        this.allColumnNamesStmt = String.join(", ", allColumnNames);
+        this.allColumnNamesStmt = joinColumnNames(allColumnNames);
         this.selectAllColumnsStmt = "SELECT " + allColumnNamesStmt + " FROM " + this.tableName + " ";
 
         this.insertStatement = buildInsertStatement();
         this.insertWildCardIndexPositions = this.prepareWildcardIndices(columnDefinitions);
+    }
+
+    public static String joinColumnNames(Stream<String> columNames) {
+        return joinColumnNames(columNames.toArray(String[]::new));
+    }
+    public static String joinColumnNames(String[] columnNames) {
+        return String.join(", ", columnNames);
     }
 
     private String buildInsertStatement() {

--- a/src/main/java/edu/byu/cs/model/Submission.java
+++ b/src/main/java/edu/byu/cs/model/Submission.java
@@ -1,5 +1,7 @@
 package edu.byu.cs.model;
 
+import edu.byu.cs.autograder.git.CommitValidation.CommitVerificationContext;
+import edu.byu.cs.autograder.git.CommitVerificationResult;
 import edu.byu.cs.util.Serializer;
 import org.eclipse.jgit.annotations.NonNull;
 import org.eclipse.jgit.annotations.Nullable;
@@ -40,6 +42,11 @@ import java.util.Objects;
  *                       <p>Old submissions will have a `null` value;
  *                       in this case, verification is assumed to equal
  *                       the {@link Submission#passed} field.</p>
+ * @param commitContext Debug. Holds the raw information provided to the
+ *                      <pre>GitVerificationStrategy</pre> for approval or denial.
+ *                      This notably contains the <pre>CommitsByDay</pre> which lists
+ *                      the exact hash codes of commits grouped by the warnings they generated.
+ * @param commitResult Debug. Holds the raw commit verification results including computed values.
  * @param verification Represents the approval of the submission.
  *                     Added only after the submission is approved manually.
  */
@@ -56,6 +63,8 @@ public record Submission(
         Rubric rubric,
         Boolean admin,
         @Nullable VerifiedStatus verifiedStatus,
+        @Nullable CommitVerificationContext commitContext,
+        @Nullable CommitVerificationResult commitResult,
         @Nullable ScoreVerification verification
 ) {
 

--- a/src/main/java/edu/byu/cs/model/Submission.java
+++ b/src/main/java/edu/byu/cs/model/Submission.java
@@ -110,6 +110,33 @@ public record Submission(
         return verifiedStatus.isApproved();
     }
 
+    /**
+     * Generates a new {@link Submission} object with certain fields updated to reflect a change in score verification.
+     * @param newScore The new score to overwrite.
+     * @param newStatus The new {@link VerifiedStatus} to overwrite.
+     * @param newVerification The new {@link ScoreVerification} to overwrite.
+     * @return {@link Submission} A new object
+     */
+    public Submission updateApproval(Float newScore, VerifiedStatus newStatus, ScoreVerification newVerification) {
+        return new Submission(
+                this.netId(),
+                this.repoUrl(),
+                this.headHash(),
+                this.timestamp(),
+                this.phase(),
+                this.passed(),
+                newScore,
+                this.rawScore(),
+                this.notes(),
+                this.rubric(),
+                this.admin(),
+                newStatus,
+                this.commitContext(),
+                this.commitResult(),
+                newVerification
+        );
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/edu/byu/cs/model/Submission.java
+++ b/src/main/java/edu/byu/cs/model/Submission.java
@@ -142,8 +142,18 @@ public record Submission(
         return serializeScoreVerification(submission.verification);
     }
     public static String serializeScoreVerification(@Nullable ScoreVerification scoreVerification) {
-        if (scoreVerification == null) return null;
-        return Serializer.serialize(scoreVerification);
+        return serializeObject(scoreVerification);
+    }
+
+    public static String serializeCommitContext(@NonNull Submission submission) {
+        return serializeObject(submission.commitContext);
+    }
+    public static String serializeCommitResult(@NonNull Submission submission) {
+        return  serializeObject(submission.commitResult);
+    }
+    private static String serializeObject(@Nullable Object obj) {
+        if (obj == null) return null;
+        return Serializer.serialize(obj);
     }
 
     public static String serializeVerifiedStatus(@NonNull Submission submission) {

--- a/src/main/java/edu/byu/cs/util/Serializer.java
+++ b/src/main/java/edu/byu/cs/util/Serializer.java
@@ -31,6 +31,11 @@ public class Serializer {
         }
     }
 
+    public static <T> T deserializeSafely(String jsonStr, Class<T> classOfT) {
+        if (jsonStr == null) return null;
+        return deserialize(jsonStr, classOfT);
+    }
+
     public static <T> T deserialize(JsonElement jsonElement, Class<T> classOfT) {
         return deserialize(jsonElement.toString(), classOfT);
     }

--- a/src/test/java/edu/byu/cs/autograder/git/GitHelperUtils.java
+++ b/src/test/java/edu/byu/cs/autograder/git/GitHelperUtils.java
@@ -233,7 +233,8 @@ public class GitHelperUtils {
             String currentHeadHash = GitHelper.getHeadHash(git);
             var maxTimeThreshold = Instant.now().plusSeconds(gradingContext.verificationConfig().forgivenessMinutesHead() * 60L);
             CommitThreshold maxThreshold = new CommitThreshold(maxTimeThreshold, currentHeadHash);
-            return gitHelper.verifyRegularCommits(git, minThreshold, maxThreshold);
+            var report = gitHelper.verifyRegularCommits(git, minThreshold, maxThreshold);
+            return report.result();
         };
     }
 

--- a/src/test/java/edu/byu/cs/autograder/score/ScorerTest.java
+++ b/src/test/java/edu/byu/cs/autograder/score/ScorerTest.java
@@ -4,6 +4,7 @@ import edu.byu.cs.autograder.GradingContext;
 import edu.byu.cs.autograder.GradingException;
 import edu.byu.cs.autograder.GradingObserver;
 import edu.byu.cs.autograder.git.CommitVerificationConfig;
+import edu.byu.cs.autograder.git.CommitVerificationReport;
 import edu.byu.cs.autograder.git.CommitVerificationResult;
 import edu.byu.cs.canvas.CanvasException;
 import edu.byu.cs.canvas.CanvasIntegration;
@@ -46,13 +47,13 @@ class ScorerTest {
 
     private static final CommitVerificationConfig standardCVConfig = new CommitVerificationConfig(10, 3, 0, 10, 3);
 
-    private static final CommitVerificationResult PASSING_COMMIT_VERIFICATION =
+    private static final CommitVerificationReport PASSING_COMMIT_VERIFICATION =
             constructCommitVerificationResult(true, false);
-    private static final CommitVerificationResult FAILING_COMMIT_VERIFICATION =
+    private static final CommitVerificationReport FAILING_COMMIT_VERIFICATION =
             constructCommitVerificationResult(false, false);
-    private static final CommitVerificationResult PASSING_CACHED_COMMIT_VERIFICATION =
+    private static final CommitVerificationReport PASSING_CACHED_COMMIT_VERIFICATION =
             constructCommitVerificationResult(true, true);
-    private static final CommitVerificationResult FAILING_CACHED_COMMIT_VERIFICATION =
+    private static final CommitVerificationReport FAILING_CACHED_COMMIT_VERIFICATION =
             constructCommitVerificationResult(false, true);
 
 
@@ -333,11 +334,11 @@ class ScorerTest {
     private Submission scoreRubric(Rubric rubric) {
         return scoreRubric(rubric, PASSING_COMMIT_VERIFICATION);
     }
-    private Submission scoreRubric(Rubric rubric, CommitVerificationResult commitVerification) {
+    private Submission scoreRubric(Rubric rubric, CommitVerificationReport commitVerification) {
         Scorer scorer = constructScorer();
         return scoreRubric(scorer, rubric, commitVerification);
     }
-    private Submission scoreRubric(Scorer scorer, Rubric rubric, CommitVerificationResult commitVerification) {
+    private Submission scoreRubric(Scorer scorer, Rubric rubric, CommitVerificationReport commitVerification) {
         try {
             return scorer.score(rubric, commitVerification);
         } catch (Exception e) {
@@ -346,7 +347,7 @@ class ScorerTest {
         return null;
     }
 
-    private static CommitVerificationResult constructCommitVerificationResult(boolean verified, boolean isCached) {
+    private static CommitVerificationReport constructCommitVerificationResult(boolean verified, boolean isCached) {
         String statusStr = verified ? "PASSING" : "FAILING";
         if (isCached) statusStr += "_CACHED";
         String headHash = "<" + statusStr + "_COMMIT_VERIFICATION>";
@@ -354,7 +355,8 @@ class ScorerTest {
         return new CommitVerificationResult(
                 verified, isCached, 0, 0, 0, false, 0,
                 "", null, null, null,
-                headHash, null);
+                headHash, null)
+                .toReport(null);
     }
 
     record Phase3SubmissionValues(float passoffPoints, float qualityPoints, float unitTestPoints, int daysLate) {}


### PR DESCRIPTION
## Overview
<!-- Give a brief overview of the changes made in this PR -->

Provides the data necessary to surface commit verification results in the web app with knowledge about the specific commits which caused issues for the student. There is enough detail in these new objects to construct a full play by play of each commit authored by the student with links to directly view the commit in GitHub if desired. It also provides debug information should we seek to understand how/why a particular decision was made.

Resolves #519.

## Details
<!-- If you feel it is helpful, list the changes made -->

- Adds two new columns to the `Submission` table which contain all the commit verification information in JSON.
- The `create table` statements have already been updated
- The necessary ALTER TABLE statements are included here:
    ```mysql
    ALTER TABLE submission
    ADD COLUMN commit_context JSON,
    ADD COLUMN commit_result JSON;
    ```

- In the server internals, we changed the call signatures of most of the `git` commit functions to return a `CommitVerificationReport` which simply contains the `CommitVerificationResult` they were originally returning PLUS the `CommitVerificationContext` which contains the rest of the interesting information.
- Some efforts were taken to reduce duplication and reuse as much code as possible while working in related areas of the code.
- Upon discussion with @webecke, we also updated the type information of the context objects to directly correlate each commit with it's particular number of line changes.
- The current data format is not designed to minimize storage, but to be as easy to use as possible. If we would rather reformat the information to save it densely, that could be undertaken.
    - I doubt whether such efforts would be worth our time currently. This commit verification data will holds a much smaller footprint than the (currently allocated) 10K characters for error stream output.
    - The total size of the data scales linearly with the number of commits authored by students in the particular phase.

### Most Important Changes

Read the commit messages for a detailed discussion about what changes were made and _why_ they were made.

- d27d4b2a (Adds new fields to `Submission`)
- b5dbefc0 (Updates SQL tables to match)
- fc80e76e (Correlates the number of line changes with a commit hash)

## Testing
<!-- How did you test this? 
     If you didn't do any testing, explain why -->
- [ ] Added/updated unit tests
- [ ] Tested edge cases
- [ ] Manual testing (if needed)

## Future Work
<!-- Discuss things that should be done in the future, 
     or related work going on in other issues/PRs.
     Delete this section if there is none. -->

- This update is a precursor to #520.
