### PR TITLE
Document CommitsByDay errors

### DIFF
--- a/docs/git-commit-verification.md
+++ b/docs/git-commit-verification.md
@@ -384,8 +384,8 @@ In order to avoid storing too much information, this data structure does not rep
 | Error Key | Description | `DefaultGitVerificationStrategy` Response |
 | :-------- | :---------- | :---------------------------------------- |
 | `missingTailHash` | This is the hash from the previous submission that was expected, but not found. | ⚠️ Warning message |
-| `excludedCommits` | The `CommitVerificationStrategy` signalled that the evaluation should be re-performed with these commits excluded for all effective purposes. | ℹ️ None; informational result only |
-| `mergeCommits` | These are merge commits. | ❌ Exclude from analysis |
+| `excludedCommits` | The `CommitVerificationStrategy` signalled that the evaluation should be re-performed with these commits excluded for all effective purposes. | ⏩ Exclude from analysis |
+| `mergeCommits` | These are merge commits. | ⏩ Exclude from analysis |
 | `commitsInPast` | These commits were authored before the tail threshold. | ⏩ Exclude from analysis |
 | `commitsInFuture` | These commits were authored after the head threshold. | ❌ Error message |
 | `commitsOutOfOrder` | These commits were not authored strictly _after_ all of their parents. | ⚠️ Warning message |

--- a/docs/git-commit-verification.md
+++ b/docs/git-commit-verification.md
@@ -371,23 +371,15 @@ These implementation details are included here because they do not contribute to
 
 The `CommitsByDay` result object contains a data structure with the following declaration: `Map<String, List<String>> erroringCommits`. This makes it a general-purpose and extensible data structure which can represent many different things.
 
+#### Design Discussion
+
 This data structure is intended to represent many _groups_ of commits which caused a particular error. The error code is the key of the `Map`, and all the full, 40-character commit hashes of every commit which triggered the error are included in the `List<String>`. If no commits trigger a particular error, the key is not inserted into the map.
 
 In order to avoid storing too much information, this data structure does not represent every commit. However, if a commit is treated special or causes a warning in some way, it will be mentioned somewhere in here.
 
 `CommitAnalytics` is responsible for producing the `CommitsByDay` record and surfacing all of this information. The behavior of "⏩ Exclude from analysis" (not marking as `excludedCommits`) is implemented by `CommitAnalytics`, but all other decisions are higher-level responses driven by the acting `CommitVerificationStrategy`. By replacing or modifying the `CommitVerficationStrategy`, users of this data can provide different responses than the defaults.
 
-When presenting this information, it is recommended to do the following:
-* Represent all error categories, potentially excluding a limited _blacklist_. This will give future errors the best chance at correct representation.
-* Combine the commit hash with the `repoUrl` to create a direct link to the commit in a new tab.
-* Focus on each group of errors:
-    * Show each group of raised errors/warnings
-    * List each commit that triggered it
-* AND/OR Focus on the linearized commit history
-    * Iterate over `linearizedCommits`
-    * Show each commit with key information in a dense format:
-        * Number of line changes
-        * All errors/warnings associated with the commit hash
+#### Possible Error Keys
 
 | Error Key | Description | `DefaultGitVerificationStrategy` Response |
 | :-------- | :---------- | :---------------------------------------- |

--- a/docs/git-commit-verification.md
+++ b/docs/git-commit-verification.md
@@ -361,3 +361,26 @@ Grader->>Observer: notifyDone(submission)
 
 Grader-->>-Grader: void
 ```
+
+## Implementation Details
+
+These implementation details are included here because they do not contribute to a high-level understanding of the overall system behavior.
+
+### `CommitsByDay::erroringCommits`
+
+The `CommitsByDay` result object contains a data structure with the following declaration: `Map<String, List<String>> erroringCommits`. This makes it a general-purpose and extensible data structure which can represent many different things.
+
+This data structure is intended to represent many _groups_ of commits which caused a particular error. The error code is the key of the `Map`, and all the full, 40-character commit hashes of every commit which triggered the error are included in the `List<String>`. If no commits trigger a particular error, the key is not inserted into the map.
+
+| Error Key | Description | `DefaultGitVerificationStrategy` Response |
+| :-------- | :---------- | :---------------------------------------- |
+| `missingTailHash` | This is the hash from the previous submission that was expected, but not found. | ⚠️ Warning message |
+| `excludedCommits` | The `CommitVerificationStrategy` signalled that the evaluation should be re-performed with these commits excluded for all effective purposes. | ℹ️ None; informational result only |
+| `mergeCommits` | These are merge commits. | ❌ Exclude from analysis |
+| `commitsInPast` | These commits were authored before the tail threshold. | ⏩ Exclude from analysis |
+| `commitsInFuture` | These commits were authored after the head threshold. | ❌ Error message |
+| `commitsOutOfOrder` | These commits were not authored strictly _after_ all of their parents. | ⚠️ Warning message |
+| `commitsBackdated` | These commits were detected as being manually backdated. | ❌ Error message |
+| `commitTimestampsDuplicated` | These commits have the exact same timestamp as some other commit. | ℹ️ None; see below |
+| `commitTimestampsDuplicated`&shy;`SubsequentOnly` | Same as the above category, except that the first commit with each timestamp is not included. | ↪️ Re-evaluate, but exclude all of these commits |
+

--- a/docs/git-commit-verification.md
+++ b/docs/git-commit-verification.md
@@ -166,7 +166,7 @@ namespace Analytics {
         +Map~String, List[String]~ erroringCommits
         +int totalCommits
         +int mergeCommits
-        +boolean commitsInOrder
+        +boolean commitsOutOfOrder
         +boolean commitsInFuture
         +boolean commitsInPast
         +boolean commitsBackdated

--- a/docs/git-commit-verification.md
+++ b/docs/git-commit-verification.md
@@ -373,6 +373,22 @@ The `CommitsByDay` result object contains a data structure with the following de
 
 This data structure is intended to represent many _groups_ of commits which caused a particular error. The error code is the key of the `Map`, and all the full, 40-character commit hashes of every commit which triggered the error are included in the `List<String>`. If no commits trigger a particular error, the key is not inserted into the map.
 
+In order to avoid storing too much information, this data structure does not represent every commit. However, if a commit is treated special or causes a warning in some way, it will be mentioned somewhere in here.
+
+`CommitAnalytics` is responsible for producing the `CommitsByDay` record and surfacing all of this information. The behavior of "⏩ Exclude from analysis" (not marking as `excludedCommits`) is implemented by `CommitAnalytics`, but all other decisions are higher-level responses driven by the acting `CommitVerificationStrategy`. By replacing or modifying the `CommitVerficationStrategy`, users of this data can provide different responses than the defaults.
+
+When presenting this information, it is recommended to do the following:
+* Represent all error categories, potentially excluding a limited _blacklist_. This will give future errors the best chance at correct representation.
+* Combine the commit hash with the `repoUrl` to create a direct link to the commit in a new tab.
+* Focus on each group of errors:
+    * Show each group of raised errors/warnings
+    * List each commit that triggered it
+* AND/OR Focus on the linearized commit history
+    * Iterate over `linearizedCommits`
+    * Show each commit with key information in a dense format:
+        * Number of line changes
+        * All errors/warnings associated with the commit hash
+
 | Error Key | Description | `DefaultGitVerificationStrategy` Response |
 | :-------- | :---------- | :---------------------------------------- |
 | `missingTailHash` | This is the hash from the previous submission that was expected, but not found. | ⚠️ Warning message |
@@ -384,4 +400,3 @@ This data structure is intended to represent many _groups_ of commits which caus
 | `commitsBackdated` | These commits were detected as being manually backdated. | ❌ Error message |
 | `commitTimestampsDuplicated` | These commits have the exact same timestamp as some other commit. | ℹ️ None; see below |
 | `commitTimestampsDuplicated`&shy;`SubsequentOnly` | Same as the above category, except that the first commit with each timestamp is not included. | ↪️ Re-evaluate, but exclude all of these commits |
-

--- a/docs/git-commit-verification.md
+++ b/docs/git-commit-verification.md
@@ -159,7 +159,8 @@ namespace Analytics {
 
     class CommitsByDay {
         +Map~String, Integer~ dayMap
-        +Map~String, Integer~ lineChangesPerCommit
+        List~String~ linearizedCommits
+        List~Integer~ linearizedLineChanges
         %% NOTE: Mermaid cannot represent nested generics with multiple types.
         %% That is why we use the square brackets instead of angled brackets.
         %% https://mermaid.js.org/syntax/classDiagram.html#generic-types

--- a/src/main/java/edu/byu/cs/analytics/CommitAnalytics.java
+++ b/src/main/java/edu/byu/cs/analytics/CommitAnalytics.java
@@ -75,7 +75,7 @@ public class CommitAnalytics {
         List<String> linearizedCommits = new LinkedList<>();
         List<Integer> linearizedLineChanges = new LinkedList<>();
         Map<String, List<String>> erroringCommits = new HashMap<>();
-        boolean commitsInOrder = true;
+        boolean commitsOutOfOrder = false;
         boolean commitsInFuture = false;
         boolean commitsInPast = false;
         boolean commitsBackdated = false;
@@ -121,7 +121,7 @@ public class CommitAnalytics {
                 if (commitTimes.seconds < getCommitTime(pc).seconds) {
                     // Verifies that all parents are older than the child
                     groupCommitsByKey(erroringCommits, "commitsOutOfOrder", commitHash);
-                    commitsInOrder = false;
+                    commitsOutOfOrder = true;
                     break;
                 }
             }
@@ -160,7 +160,7 @@ public class CommitAnalytics {
         return new CommitsByDay(
                 days, linearizedCommits, linearizedLineChanges, erroringCommits,
                 singleParentCommits, mergeCommits,
-                !commitsInOrder, commitsInFuture, commitsInPast, commitsBackdated, commitsWithSameTimestamp, missingTailHash,
+                commitsOutOfOrder, commitsInFuture, commitsInPast, commitsBackdated, commitsWithSameTimestamp, missingTailHash,
                 lowerBound, upperBound);
     }
 

--- a/src/main/java/edu/byu/cs/analytics/CommitAnalytics.java
+++ b/src/main/java/edu/byu/cs/analytics/CommitAnalytics.java
@@ -114,7 +114,7 @@ public class CommitAnalytics {
             for (var pc : getCommitParents(git, rc)) {
                 if (commitTimes.seconds < getCommitTime(pc).seconds) {
                     // Verifies that all parents are older than the child
-                    groupCommitsByKey(erroringCommits, "commitsInOrder", commitHash);
+                    groupCommitsByKey(erroringCommits, "commitsOutOfOrder", commitHash);
                     commitsInOrder = false;
                     break;
                 }
@@ -153,7 +153,7 @@ public class CommitAnalytics {
         return new CommitsByDay(
                 days, lineChangesPerCommit, erroringCommits,
                 singleParentCommits, mergeCommits,
-                commitsInOrder, commitsInFuture, commitsInPast, commitsBackdated, commitsWithSameTimestamp, missingTailHash,
+                !commitsInOrder, commitsInFuture, commitsInPast, commitsBackdated, commitsWithSameTimestamp, missingTailHash,
                 lowerBound, upperBound);
     }
 

--- a/src/main/java/edu/byu/cs/analytics/CommitAnalytics.java
+++ b/src/main/java/edu/byu/cs/analytics/CommitAnalytics.java
@@ -123,6 +123,7 @@ public class CommitAnalytics {
             // Skip merge commits
             if (rc.getParentCount() > 1) {
                 ++mergeCommits;
+                groupCommitsByKey(erroringCommits, "mergeCommits", commitHash);
                 continue;
             }
 

--- a/src/main/java/edu/byu/cs/analytics/CommitsByDay.java
+++ b/src/main/java/edu/byu/cs/analytics/CommitsByDay.java
@@ -6,8 +6,10 @@ import java.util.*;
  * Contains the results of a commit analytics parse,
  * including the parameters used to generate it.
  * <br>
- * This data structure is intended for use <i>only</i> within the system processing memory.
- * It is not intended to be persisted in a database or other data structure.
+ * This data structure is stored alongside ever {@link edu.byu.cs.model.Submission} entry.
+ * Therefore, this data model is more concerned about stringified storage space and use in
+ * back-end detection of errors than in user presentation. Presenting the information contained
+ * within will likely require converting the data into a more friendly format.
  *
  * @param dayMap Represents each of the calendar days,
  *               with the number of commits on that day.

--- a/src/main/java/edu/byu/cs/analytics/CommitsByDay.java
+++ b/src/main/java/edu/byu/cs/analytics/CommitsByDay.java
@@ -11,8 +11,13 @@ import java.util.*;
  *
  * @param dayMap Represents each of the calendar days,
  *               with the number of commits on that day.
- * @param lineChangesPerCommit One entry for each commit processed, representing the full commit hash
- *                            and the number of lines changed in the commit.
+ * @param linearizedCommits The linearized order of all commits evaluated where earlier commits appear sooner.
+ *                          This order generally corresponds to author time, but may not match exactly
+ *                          when branches and merging occurs.
+ * @param linearizedLineChanges A corresponding list to {@link CommitsByDay#linearizedCommits()} which provides
+ *                              a single number for every commit representing the number of line changes.
+ *                              If the line changes for some commit were never computed, it will be included
+ *                              with the value of <b>-1</b>.
  * @param erroringCommits Reports commit hashes that triggered any of the failure conditions,
  *                        grouped by a natural key into the kinds of conditions that they failed.
  *                        This will be empty when there are no erroring commits.
@@ -31,7 +36,8 @@ import java.util.*;
  */
 public record CommitsByDay(
         Map<String, Integer> dayMap,
-        Map<String, Integer> lineChangesPerCommit,
+        List<String> linearizedCommits,
+        List<Integer> linearizedLineChanges,
         Map<String, List<String>> erroringCommits,
         int totalCommits,
         int mergeCommits,

--- a/src/main/java/edu/byu/cs/analytics/CommitsByDay.java
+++ b/src/main/java/edu/byu/cs/analytics/CommitsByDay.java
@@ -18,7 +18,7 @@ import java.util.*;
  *                        This will be empty when there are no erroring commits.
  * @param totalCommits The total number of commits processed, excluding merge commits.
  * @param mergeCommits The total number of merge commits.
- * @param commitsInOrder Reports whether all commits were authored strictly after their parents.
+ * @param commitsOutOfOrder Reports whether any commits were not authored strictly after their parents.
  * @param commitsInPast Reports whether any commits were found before the tail hash chronologically.
  *                      This flag has been deemed unhelpful and intentionally ignored.
  *                      Therefore, these are NOT counted as erroring commits.
@@ -35,7 +35,7 @@ public record CommitsByDay(
         Map<String, List<String>> erroringCommits,
         int totalCommits,
         int mergeCommits,
-        boolean commitsInOrder,
+        boolean commitsOutOfOrder,
         boolean commitsInFuture,
         boolean commitsInPast,
         boolean commitsBackdated,

--- a/src/main/java/edu/byu/cs/autograder/git/CommitValidation/DefaultGitVerificationStrategy.java
+++ b/src/main/java/edu/byu/cs/autograder/git/CommitValidation/DefaultGitVerificationStrategy.java
@@ -55,7 +55,7 @@ public class DefaultGitVerificationStrategy implements CommitVerificationStrateg
                         !insufficientDaysWithCommits && daysWithCommits < requiredDaysWithCommits && daysSubmittedEarly > 0,
                         String.format("Committed %d of %d required days, but early completion made up the difference.", daysWithCommits, requiredDaysWithCommits)),
                 new CV(
-                        !commitsByDay.commitsInOrder(),
+                        commitsByDay.commitsOutOfOrder(),
                         "Congratulations! You have changed the order of some of your commits. You won a medal for manipulating your git history in advanced ways🏅"),
                 new CV(
                         commitsByDay.commitTimestampsDuplicated(),

--- a/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
+++ b/src/main/java/edu/byu/cs/autograder/git/GitHelper.java
@@ -253,7 +253,7 @@ public class GitHelper {
 
             int numCommits = commitsByDay.totalCommits();
             int daysWithCommits = commitsByDay.dayMap().size();
-            long significantCommits = commitsByDay.lineChangesPerCommit().values()
+            long significantCommits = commitsByDay.linearizedLineChanges()
                     .stream().filter(i -> i >= minimumLinesChangedPerCommit).count();
 
             CommitVerificationContext context = new CommitVerificationContext(


### PR DESCRIPTION
## Overview
<!-- Give a brief overview of the changes made in this PR -->

In support of #520, this provides helpful documentation that shows exactly what kinds of information is contained in the `CommitsByDay` errors map. This field is special because it is intended to be extensible; the rest of the fields are documented directly in the JavaDoc.

## Details
<!-- If you feel it is helpful, list the changes made -->

- Adds documentation
- Makes minor adjustments to provide better detter
- Updates all relevant documentation
- All tests still pass
- This also supports #444 

## Testing
<!-- How did you test this? 
     If you didn't do any testing, explain why -->
- [x] Added/updated unit tests
- [ ] Tested edge cases
- [ ] Manual testing (if needed)

## Future Work
<!-- Discuss things that should be done in the future, 
     or related work going on in other issues/PRs.
     Delete this section if there is none. -->

- This work will support and make easier issue #520.
