### PR TITLE
Fix Downloads tab functionality

### DIFF
--- a/src/main/java/edu/byu/cs/analytics/CommitAnalytics.java
+++ b/src/main/java/edu/byu/cs/analytics/CommitAnalytics.java
@@ -471,23 +471,25 @@ public class CommitAnalytics {
      *
      * @return A map section to map of netID to list of timestamp
      */
-    private static Map<String, Map<String, ArrayList<Integer>>> compile() throws CanvasException {
+    private static Map<String, Map<String, ArrayList<Integer>>> compile() throws CanvasException, DataAccessException {
 
         Map<String, Map<String, ArrayList<Integer>>> commitsBySection = new TreeMap<>();
 
         CanvasSection[] sections = CanvasService.getCanvasIntegration().getAllSections();
         for (CanvasSection section: sections) {
 
-            Collection<User> students;
+            Collection<String> studentNetIds;
             Map<String, ArrayList<Integer>> commitMap = new TreeMap<>();
 
             try {
-                students = CanvasService.getCanvasIntegration().getAllStudentsBySection(section.id());
+                studentNetIds = CanvasService.getCanvasIntegration().getAllStudentNetIdsBySection(section.id());
             } catch (CanvasException e) {
                 throw new RuntimeException("Canvas Exception: " + e.getMessage());
             }
 
-            for (User student : students) {
+            for (String netId : studentNetIds) {
+                User student = DaoService.getUserDao().getUser(netId);
+                if (student == null || student.repoUrl() == null) continue;
                 File repoPath = new File("./tmp-" + student.repoUrl().hashCode());
 
                 CloneCommand cloneCommand = Git.cloneRepository()

--- a/src/main/java/edu/byu/cs/canvas/CanvasIntegration.java
+++ b/src/main/java/edu/byu/cs/canvas/CanvasIntegration.java
@@ -20,7 +20,7 @@ public interface CanvasIntegration {
      */
     User getUser(String netId) throws CanvasException;
 
-    Collection<User> getAllStudentsBySection(int sectionID) throws CanvasException;
+    Collection<String> getAllStudentNetIdsBySection(int sectionID) throws CanvasException;
 
 
     /**

--- a/src/main/java/edu/byu/cs/canvas/CanvasIntegration.java
+++ b/src/main/java/edu/byu/cs/canvas/CanvasIntegration.java
@@ -20,14 +20,6 @@ public interface CanvasIntegration {
      */
     User getUser(String netId) throws CanvasException;
 
-    /**
-     * Queries Canvas for every student with a Git repo URL submission
-     *
-     * @return A set of user objects
-     * @throws CanvasException If there is an error with Canvas' response
-     */
-    Collection<User> getAllStudents() throws CanvasException;
-
     Collection<User> getAllStudentsBySection(int sectionID) throws CanvasException;
 
 

--- a/src/main/java/edu/byu/cs/canvas/CanvasIntegrationImpl.java
+++ b/src/main/java/edu/byu/cs/canvas/CanvasIntegrationImpl.java
@@ -23,6 +23,7 @@ import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.time.ZonedDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class CanvasIntegrationImpl implements CanvasIntegration {
 
@@ -33,8 +34,6 @@ public class CanvasIntegrationImpl implements CanvasIntegration {
     private record Enrollment(EnrollmentType type) {}
 
     private record CanvasUser(int id, String sortable_name, String login_id, Enrollment[] enrollments) {}
-
-    private record CanvasSubmissionUser(String url, CanvasUser user) {}
 
     private record CanvasResponse<T>(
             T body,
@@ -72,25 +71,13 @@ public class CanvasIntegrationImpl implements CanvasIntegration {
     }
 
     @Override
-    public Collection<User> getAllStudentsBySection(int sectionID) throws CanvasException {
-        return getMultipleStudents("/sections/" + sectionID + "/assignments/" +
-                getGitHubAssignmentNumber() + "/submissions?include[]=user");
-    }
-
-    private static Collection<User> getMultipleStudents(String baseUrl) throws CanvasException {
-        List<CanvasSubmissionUser> allSubmissions = makePaginatedCanvasRequest(baseUrl, CanvasSubmissionUser.class);
-
-        Set<User> allStudents = new HashSet<>();
-        for (CanvasSubmissionUser sub : allSubmissions) {
-            if (sub.url == null) continue;
-            CanvasUser user = sub.user;
-            String[] names = user.sortable_name().split(",");
-            String firstName = ((names.length >= 2) ? names[1] : "").trim();
-            String lastName = ((names.length >= 1) ? names[0] : "").trim();
-            allStudents.add(new User(user.login_id, user.id, firstName, lastName, sub.url, User.Role.STUDENT));
-        }
-
-        return allStudents;
+    public Collection<String> getAllStudentNetIdsBySection(int sectionID) throws CanvasException {
+        return makeCanvasRequest("GET",
+                "/courses/" + getCourseNumber() + "/sections/" + sectionID + "?include[]=students",
+                CanvasSection.class)
+                .body().students().stream()
+                .map(CanvasSection.CanvasSectionStudent::login_id)
+                .collect(Collectors.toCollection(HashSet::new));
     }
 
     /**
@@ -319,15 +306,6 @@ public class CanvasIntegrationImpl implements CanvasIntegration {
                     Integer.class);
         } catch (DataAccessException e) {
             throw new CanvasException("Error when trying to retrieve the Course Number from the database:" + e);
-        }
-    }
-
-    private static Integer getGitHubAssignmentNumber() throws CanvasException {
-        try {
-            return PhaseUtils.getPhaseAssignmentNumber(Phase.GitHub);
-        } catch (DataAccessException e) {
-            throw new CanvasException("Error when trying to retrieve the GitHub Assignment Number from the database:"
-                    + e);
         }
     }
 

--- a/src/main/java/edu/byu/cs/canvas/CanvasIntegrationImpl.java
+++ b/src/main/java/edu/byu/cs/canvas/CanvasIntegrationImpl.java
@@ -72,12 +72,6 @@ public class CanvasIntegrationImpl implements CanvasIntegration {
     }
 
     @Override
-    public Collection<User> getAllStudents() throws CanvasException {
-        return getMultipleStudents("/courses/" + getCourseNumber() + "/assignments/" +
-                getGitHubAssignmentNumber() + "/submissions?include[]=user");
-    }
-
-    @Override
     public Collection<User> getAllStudentsBySection(int sectionID) throws CanvasException {
         return getMultipleStudents("/sections/" + sectionID + "/assignments/" +
                 getGitHubAssignmentNumber() + "/submissions?include[]=user");

--- a/src/main/java/edu/byu/cs/canvas/CanvasIntegrationImpl.java
+++ b/src/main/java/edu/byu/cs/canvas/CanvasIntegrationImpl.java
@@ -73,8 +73,8 @@ public class CanvasIntegrationImpl implements CanvasIntegration {
     @Override
     public Collection<String> getAllStudentNetIdsBySection(int sectionID) throws CanvasException {
         return makeCanvasRequest("GET",
-                "/courses/" + getCourseNumber() + "/sections/" + sectionID + "?include[]=students",
-                CanvasSection.class)
+                    "/courses/" + getCourseNumber() + "/sections/" + sectionID + "?include[]=students",
+                    CanvasSection.class)
                 .body().students().stream()
                 .map(CanvasSection.CanvasSectionStudent::login_id)
                 .collect(Collectors.toCollection(HashSet::new));

--- a/src/main/java/edu/byu/cs/canvas/FakeCanvasIntegration.java
+++ b/src/main/java/edu/byu/cs/canvas/FakeCanvasIntegration.java
@@ -28,7 +28,7 @@ public class FakeCanvasIntegration implements CanvasIntegration {
 
 
     @Override
-    public Collection<User> getAllStudentsBySection(int sectionID) {
+    public Collection<String> getAllStudentNetIdsBySection(int sectionID) {
         return new HashSet<>();
     }
 
@@ -60,6 +60,6 @@ public class FakeCanvasIntegration implements CanvasIntegration {
 
     @Override
     public CanvasSection[] getAllSections() throws CanvasException {
-        return new CanvasSection[]{new CanvasSection(0, "Fake Section")};
+        return new CanvasSection[]{new CanvasSection(0, "Fake Section", new HashSet<>())};
     }
 }

--- a/src/main/java/edu/byu/cs/canvas/FakeCanvasIntegration.java
+++ b/src/main/java/edu/byu/cs/canvas/FakeCanvasIntegration.java
@@ -26,10 +26,6 @@ public class FakeCanvasIntegration implements CanvasIntegration {
         return user;
     }
 
-    @Override
-    public Collection<User> getAllStudents() {
-        return new HashSet<>();
-    }
 
     @Override
     public Collection<User> getAllStudentsBySection(int sectionID) {

--- a/src/main/java/edu/byu/cs/canvas/model/CanvasSection.java
+++ b/src/main/java/edu/byu/cs/canvas/model/CanvasSection.java
@@ -1,3 +1,7 @@
 package edu.byu.cs.canvas.model;
 
-public record CanvasSection (Integer id, String name) {}
+import java.util.Collection;
+
+public record CanvasSection (Integer id, String name, Collection<CanvasSectionStudent> students) {
+    public record CanvasSectionStudent (String login_id) {}
+}

--- a/src/main/java/edu/byu/cs/honorChecker/HonorCheckerCompiler.java
+++ b/src/main/java/edu/byu/cs/honorChecker/HonorCheckerCompiler.java
@@ -3,6 +3,8 @@ package edu.byu.cs.honorChecker;
 import edu.byu.cs.canvas.CanvasException;
 import edu.byu.cs.canvas.CanvasService;
 import edu.byu.cs.canvas.model.CanvasSection;
+import edu.byu.cs.dataAccess.DaoService;
+import edu.byu.cs.dataAccess.DataAccessException;
 import edu.byu.cs.model.User;
 import edu.byu.cs.util.FileUtils;
 import org.eclipse.jgit.api.CloneCommand;
@@ -22,7 +24,7 @@ public class HonorCheckerCompiler {
      * @param sectionID the section ID
      * @return the path to the .zip file
      */
-    public static String compileSection(int sectionID) throws CanvasException {
+    public static String compileSection(int sectionID) throws CanvasException, DataAccessException {
         Optional<CanvasSection> canvasSection = Arrays.stream(CanvasService.getCanvasIntegration().getAllSections())
                 .filter(cs -> sectionID == cs.id()).findFirst();
         if (canvasSection.isEmpty()) throw new CanvasException("Could not find specified section");
@@ -31,21 +33,25 @@ public class HonorCheckerCompiler {
 
         FileUtils.createDirectory(tmpDir);
 
-        Collection<User> students;
+        Collection<String> studentNetIds;
         try {
-            students = CanvasService.getCanvasIntegration().getAllStudentsBySection(sectionID);
+            studentNetIds = CanvasService.getCanvasIntegration().getAllStudentNetIdsBySection(sectionID);
         } catch (CanvasException e) {
             throw new RuntimeException("Canvas Exception: " + e.getMessage());
         }
 
         try {
-            for (User student : students) {
-                if (student.firstName().equals("Test") && student.lastName().equals("Student")) continue;
+            for (String netId : studentNetIds) {
+                User student = DaoService.getUserDao().getUser(netId);
+                if (student == null || student.repoUrl() == null ||
+                        (student.firstName().equals("Test") && student.lastName().equals("Student"))) continue;
                 File repoPath = new File(tmpDir, String.join("_", student.firstName().replace(' ', '_'),
                         student.lastName().replace(' ', '_'), student.netId()));
 
+                User dbStudent = DaoService.getUserDao().getUser(student.netId());
+                if(dbStudent == null) continue;
                 CloneCommand cloneCommand = Git.cloneRepository()
-                        .setURI(student.repoUrl())
+                        .setURI(dbStudent.repoUrl())
                         .setDirectory(repoPath);
 
                 try {
@@ -77,7 +83,7 @@ public class HonorCheckerCompiler {
             }
 
             FileUtils.zipDirectory(tmpDir, zipFilePath);
-        } catch (RuntimeException e) {
+        } catch (RuntimeException | DataAccessException e) {
             FileUtils.removeDirectory(new File(tmpDir));
             new File(zipFilePath).delete();
             throw e;

--- a/src/main/java/edu/byu/cs/service/AdminService.java
+++ b/src/main/java/edu/byu/cs/service/AdminService.java
@@ -130,7 +130,7 @@ public class AdminService {
         };
     }
 
-    public static void streamHonorCheckerZip(String sectionStr, OutputStream os) throws CanvasException, IOException {
+    public static void streamHonorCheckerZip(String sectionStr, OutputStream os) throws CanvasException, IOException, DataAccessException {
         String filePath = HonorCheckerCompiler.compileSection(Integer.parseInt(sectionStr));
 
         try (FileInputStream fis = new FileInputStream(filePath)) {


### PR DESCRIPTION
## Overview
The Commit Analytics and Honor Checker were giving back empty files. This fixes that.

## Details
There was a method that was relying on the submissions to the GitHub Repository Assignment in Canvas (which we no longer require). It has been replaced with a method that just gives a set of NetID's of students in the section, and the code that was calling it has been updated to use the new method and retrieve the other info from the database.

## Testing
<!-- How did you test this? 
     If you didn't do any testing, explain why -->
- [ ] Added/updated unit tests
- [ ] Tested edge cases
- [x] Manual testing (if needed)

