### PR TITLE
Update StandardAPITests to the Fixed One for Login Bad Request

### DIFF
--- a/src/main/resources/phases/phase3/passoff/server/StandardAPITests.java
+++ b/src/main/resources/phases/phase3/passoff/server/StandardAPITests.java
@@ -79,7 +79,6 @@ public class StandardAPITests {
         TestUser[] incompleteLoginRequests = {
             new TestUser(null, existingUser.getPassword(), existingUser.getEmail()),
             new TestUser(existingUser.getUsername(), null, existingUser.getEmail()),
-            new TestUser(existingUser.getUsername(), existingUser.getPassword(), null),
         };
 
         for (TestUser incompleteLoginRequest : incompleteLoginRequests) {


### PR DESCRIPTION
## Overview
This updates the StandardAPITests in the AutoGrader to the new one merged into the Chess repo from the [Remove Login Bad Request Email Line PR](https://github.com/softwareconstruction240/chess/pull/31).