### PR TITLE
Removed Unused RegisterRequest Record

### DIFF
--- a/src/main/java/edu/byu/cs/controller/netmodel/RegisterRequest.java
+++ b/src/main/java/edu/byu/cs/controller/netmodel/RegisterRequest.java
@@ -1,4 +1,0 @@
-package edu.byu.cs.controller.netmodel;
-
-public record RegisterRequest(String firstName, String lastName, String repoUrl) {
-}


### PR DESCRIPTION
## Overview
Resolves #581. The RegisterRequest record, which was used before integration with Canvas setup, is now completely unused and this PR removes it.