### PR TITLE
Update Required Packages to Test

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/compile/verifers/TestLocationVerifier.java
+++ b/src/main/java/edu/byu/cs/autograder/compile/verifers/TestLocationVerifier.java
@@ -57,7 +57,7 @@ public class TestLocationVerifier implements StudentCodeVerifier {
 
         Phase currPhase = context.phase();
         do {
-            for (String unitTestPackagePath : PhaseUtils.unitTestPackagePaths(currPhase)) {
+            for (String unitTestPackagePath : PhaseUtils.requiredTestPackagePaths(currPhase)) {
                 File packageDirectory = new File(context.stageRepo(), unitTestPackagePath);
                 if (!packageDirectory.isDirectory()) {
                     missingPackages.add(unitTestPackagePath);

--- a/src/main/java/edu/byu/cs/util/PhaseUtils.java
+++ b/src/main/java/edu/byu/cs/util/PhaseUtils.java
@@ -103,7 +103,7 @@ public class PhaseUtils {
 
     public static Set<String> passoffPackagesToTest(Phase phase) throws GradingException {
         return switch (phase) {
-            case Phase0 -> Set.of("passoff.chess", "passoff.chess.piece");
+            case Phase0 -> Set.of("passoff.chess", "passoff.chess.piecemoves");
             case Phase1 -> Set.of("passoff.chess.game", "passoff.chess.extracredit");
             case Phase3, Phase4, Phase6 -> Set.of("passoff.server");
             case Phase5, Quality, GitHub, Commits -> throw new GradingException("No passoff tests for this phase");
@@ -119,7 +119,7 @@ public class PhaseUtils {
         };
     }
 
-    public static Set<String> unitTestPackagePaths(Phase phase) {
+    public static Set<String> requiredTestPackagePaths(Phase phase) {
         return switch (phase) {
             case Phase0, Phase6, Quality, GitHub, Commits -> new HashSet<>();
             case Phase1 -> Set.of("shared/src/test/java/passoff/chess/game");


### PR DESCRIPTION
## Overview
This PR:
- Updated the passoffPackagesToTest for phase 0 from "passoff.chess.piece" to "passoff.chess.piecemoves".
- Renamed "unitTestPackagePaths" to "requiredTestPackagePaths" for better accuracy.