### PR TITLE
Update Devcontainer JSON - Maven SDKMan

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,9 @@
 	},
 	"forwardPorts": [8080, 5173],
 	"features": {
-		"ghcr.io/devcontainers-contrib/features/maven-sdkman:2": {},
+    "ghcr.io/devcontainers-contrib/features/maven-sdkman:2": {
+      "version": "3.9.8"
+    },
 		"ghcr.io/devcontainers/features/node:1": {}
 	}
 }


### PR DESCRIPTION
## Overview
For some reason, building the dev container with the latest version of the maven-sdkman is giving an issue. This PR switches to a previous version where the ZIP file is valid, prevents this issue.

## The issue in Question
In case anyone is curious what the issue originally was, here is the full log:
```
Connecting to Docker... Cannot connect to the Docker daemon at npipe:////./pipe/docker_engine. Is the docker daemon running?
Connecting to Docker... Connected
Setting up container features:
Downloading maven-sdkman feature manifest...
Downloading node feature manifest...
Creating jb-devcontainer-features-a742d7ef8671c2d6f699a9909d63b4a9...
Building image…
Preparing build context archive…
[==================================================>]14/14 files
Done

Sending build context to Docker daemon…
[==================================================>] 10.55kB
Done

Step 1/2 : FROM scratch
 --->
Step 2/2 : COPY . /tmp/jb-devcontainer-features
 ---> 114d21bfb307

Successfully built 114d21bfb307
Successfully tagged jb-devcontainer-features-a742d7ef8671c2d6f699a9909d63b4a9:latest
Preparing helper container for git clone...
Initializing remote agent...
Cloning into '.'...
remote: Enumerating objects: 31683, done.
remote: Counting objects: 100% (2741/2741), done.
remote: Compressing objects: 100% (602/602), done.
remote: Total 31683 (delta 2186), reused 2228 (delta 2087), pack-reused 28942 (from 3)
Receiving objects: 100% (31683/31683), 56.34 MiB | 5.20 MiB/s, done.
Resolving deltas: 100% (13850/13850), done.

[+] Building 40.0s (8/9)                                         docker:default
 => [internal] load build definition from .features.temp.dockerfile        0.0s
 => => transferring dockerfile: 1.39kB                                     0.0s
 => [internal] load metadata for docker.io/library/jb-devcontainer-featur  0.0s
 => [internal] load metadata for mcr.microsoft.com/devcontainers/java:21   0.0s
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 2B                                            0.0s
 => FROM docker.io/library/jb-devcontainer-features-a742d7ef8671c2d6f699a  0.0s
 => CACHED [stage-0 1/4] FROM mcr.microsoft.com/devcontainers/java:21      0.0s
 => [stage-0 2/4] COPY --from=jb-devcontainer-features-a742d7ef8671c2d6f6  0.1s
 => ERROR [stage-0 3/4] RUN chmod -R 0755 /tmp/jb-devcontainer-features/  39.8s
------
 > [stage-0 3/4] RUN chmod -R 0755 /tmp/jb-devcontainer-features/ghcr.io-devcont
ainers-contrib-features-maven-sdkman-2 && cd /tmp/jb-devcontainer-features/ghcr.
io-devcontainers-contrib-features-maven-sdkman-2 && chmod +x ./devcontainer-feat
ure-setup.sh && ./devcontainer-feature-setup.sh:
0.229 Installing maven-sdkman feature...
0.246 bash: cannot set terminal process group (1): Inappropriate ioctl for devic
e
0.246 bash: no job control in this shell
2.459 nanolayer
5.650 cd /tmp/tmpjskync09 && chmod +x -R . && _REMOTE_USER="vscode" _REMOTE_USER
_HOME="/home/vscode" CANDIDATE="none" VERSION="none" NANOLAYER_VERBOSE="" NANOLA
YER_FORCE_CLI_INSTALLATION="" NANOLAYER_PROPAGATE_CLI_LOCATION="1" NANOLAYER_CLI
_LOCATION="/tmp/nanolayer-6XL6p9I2cO/nanolayer" bash  -i  +H ./install.sh
5.650 Done!
8.403 cd /tmp/tmposjtn54u && chmod +x -R . && _REMOTE_USER="vscode" _REMOTE_USER
_HOME="/home/vscode" COMMAND="echo sdkman_auto_answer=true > ${SDKMAN_DIR}/etc/c
onfig" NANOLAYER_VERBOSE="" NANOLAYER_FORCE_CLI_INSTALLATION="" NANOLAYER_PROPAG
ATE_CLI_LOCATION="1" NANOLAYER_CLI_LOCATION="/tmp/nanolayer-6XL6p9I2cO/nanolayer
" bash  -i  +H ./install.sh
8.403 + rm -rf '/var/lib/apt/lists/*'
8.404 + bash -c 'echo sdkman_auto_answer=true > /usr/local/sdkman/etc/config'
8.405 + rm -rf '/var/lib/apt/lists/*'
8.406 + echo 'Done!'
8.406 Done!
12.07 cd /tmp/tmpjzvtsviw && chmod +x -R . && _REMOTE_USER="vscode" _REMOTE_USER
_HOME="/home/vscode" JDKDISTRO="ms" VERSION="latest" INSTALLGRADLE="false" GRADL
EVERSION="latest" INSTALLMAVEN="false" MAVENVERSION="latest" INSTALLANT="false"
ANTVERSION="latest" NANOLAYER_VERBOSE="" NANOLAYER_FORCE_CLI_INSTALLATION="" NAN
OLAYER_PROPAGATE_CLI_LOCATION="1" NANOLAYER_CLI_LOCATION="/tmp/nanolayer-6XL6p9I
2cO/nanolayer" bash  -i  +H ./install.sh
12.07
12.07 Downloading: java 21.0.7-tem
12.07
12.07 In progress...
12.07
12.20 #=#=#
######################################################################### 100.0%
20.52
20.52 Repackaging Java 21.0.7-tem...
31.12
31.12 Done repackaging...
32.79
32.79 Checksums are disabled, skipping verification...
32.79
32.79 Installing: java 21.0.7-tem
34.66 Done installing!
34.66
34.66
34.66 Setting java 21.0.7-tem as default.
34.87 4 archive(s) flushed, freeing 202M        /usr/local/sdkman/tmp.
34.87 1 archive(s) flushed, freeing 8.0K        /usr/local/sdkman/var/metadata.
35.07 0 archive(s) flushed, freeing 4.0K        /usr/local/sdkman/tmp.
35.07 Done!
38.47 cd /tmp/tmphweayuw0 && chmod +x -R . && _REMOTE_USER="vscode" _REMOTE_USER
_HOME="/home/vscode" CANDIDATE="maven" VERSION="latest" NANOLAYER_VERBOSE="" NAN
OLAYER_FORCE_CLI_INSTALLATION="" NANOLAYER_PROPAGATE_CLI_LOCATION="1" NANOLAYER_
CLI_LOCATION="/tmp/nanolayer-6XL6p9I2cO/nanolayer" bash  -i  +H ./install.sh
38.47
38.47 Downloading: maven 3.9.9
38.47
38.47 In progress...
38.47
38.59 #=#=#
######################################################################### 100.0%
39.44   End-of-central-directory signature not found.  Either this file is not
39.44   a zipfile, or it constitutes one disk of a multi-part archive.  In the
39.44   latter case the central directory and zipfile comment will be found on
39.44   the last disk(s) of this archive.
39.44 unzip:  cannot find zipfile directory in one of /usr/local/sdkman/tmp/mave
n-3.9.9.zip or
39.44         /usr/local/sdkman/tmp/maven-3.9.9.zip.zip, and cannot find /usr/lo
cal/sdkman/tmp/maven-3.9.9.zip.ZIP, period.
39.44
39.44 Stop! The archive was corrupt and has been removed! Please try installing
again.
39.48 Traceback (most recent call last):
39.48   File "<string>", line 1, in <module>
39.48   File "nanolayer.__main__", line 50, in main
39.48   File "typer.main", line 328, in __call__
39.49   File "typer.main", line 311, in __call__
39.49   File "click.core", line 1130, in __call__
39.49   File "typer.core", line 778, in main
39.49   File "typer.core", line 216, in _main
39.49   File "click.core", line 1657, in invoke
39.49   File "click.core", line 1657, in invoke
39.49   File "click.core", line 1404, in invoke
39.49   File "click.core", line 760, in invoke
39.49   File "typer.main", line 683, in wrapper
39.49   File "nanolayer.cli.install", line 64, in install_devcontainer_feature
39.49   File "nanolayer.installers.devcontainer_feature.oci_feature_installer",
line 131, in install
39.49   File "nanolayer.utils.invoker", line 56, in invoke
39.49 nanolayer.utils.invoker.Invoker.InvokerException: The command 'cd /tmp/tmp
hweayuw0 && chmod +x -R . && _REMOTE_USER="vscode" _REMOTE_USER_HOME="/home/vsco
de" CANDIDATE="maven" VERSION="latest" NANOLAYER_VERBOSE="" NANOLAYER_FORCE_CLI_
INSTALLATION="" NANOLAYER_PROPAGATE_CLI_LOCATION="1" NANOLAYER_CLI_LOCATION="/tm
p/nanolayer-6XL6p9I2cO/nanolayer" bash  -i  +H ./install.sh' failed. error: Retu
rn Code: 1. see logs for details.
39.59 Sentry is attempting to send 2 pending error messages
39.59 Waiting up to 2 seconds
39.59 Press Ctrl-C to quit
------
.features.temp.dockerfile:10
--------------------
   9 |
  10 | >>> RUN chmod -R 0755 /tmp/jb-devcontainer-features/ghcr.io-devcontainers
-contrib-features-maven-sdkman-2 \
  11 | >>> && cd /tmp/jb-devcontainer-features/ghcr.io-devcontainers-contrib-fea
tures-maven-sdkman-2 \
  12 | >>> && chmod +x ./devcontainer-feature-setup.sh \
  13 | >>> && ./devcontainer-feature-setup.sh
  14 |     ENV NVM_DIR="/usr/local/share/nvm"
--------------------
ERROR: failed to solve: process "/bin/sh -c chmod -R 0755 /tmp/jb-devcontainer-f
eatures/ghcr.io-devcontainers-contrib-features-maven-sdkman-2 && cd /tmp/jb-devc
ontainer-features/ghcr.io-devcontainers-contrib-features-maven-sdkman-2 && chmod
 +x ./devcontainer-feature-setup.sh && ./devcontainer-feature-setup.sh" did not
complete successfully: exit code: 1

View build details: docker-desktop://dashboard/build/default/default/5nfg2mwwo2w
eef3tm04lrxeeh
Image build failed with exit code 1.
```