### PR TITLE
Allow annotation dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,13 +132,6 @@
             <artifactId>slf4j-api</artifactId>
             <version>2.0.13</version>
         </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>5.10.0</version>
-            <scope>test</scope>
-        </dependency>
-
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,13 @@
             <version>6.9.0.202403050737-r</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.jetbrains/annotations -->
+         <dependency>
+             <groupId>org.jetbrains</groupId>
+             <artifactId>annotations</artifactId>
+             <version>26.0.2</version>
+         </dependency>
+
         <!-- https://mvnrepository.com/artifact/io.javalin/javalin -->
         <dependency>
             <groupId>io.javalin</groupId>

--- a/src/main/resources/phases/pom/pom.xml
+++ b/src/main/resources/phases/pom/pom.xml
@@ -32,5 +32,18 @@
             <artifactId>junit-jupiter</artifactId>
             <version>5.9.2</version>
         </dependency>
+
+        <!-- These following dependencies are injected to allow IDE annotations if there are any -->
+        <!-- The same dependencies exist within the autograder and were copied from there -->
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>26.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>6.9.0.202403050737-r</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Overview
Added `org.intellij` and `org.eclipse.jgit` dependencies to submission injected pom.xml.

## Details
These dependencies used in the autograder were added to the pom.xml used solely when injected into students' projects when run through the autograder to allow the usage of annotations if the student decided to include them, incurring in any other changes to any students who didn't.

Closes #596 

## Future Work
If we feel like it's needed or desired, we could include these in the pom.xml given through the starter code so they can be used without problems if students decide to use them, but I don't think that is necessary, as it might confuse students. However, most students don't run their project through Maven, so this is a topic for discussion in a separate issue in the correct repository.

Likewise, a note in the instructions could be useful, but is out of scope of this PR and the issue it solves.