### PR TITLE
Update Autograder Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>io.javalin</groupId>
             <artifactId>javalin</artifactId>
-            <version>6.3.0</version>
+            <version>6.6.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->

--- a/pom.xml
+++ b/pom.xml
@@ -125,12 +125,6 @@
             <artifactId>slf4j-api</artifactId>
             <version>2.0.13</version>
         </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>5.10.0</version>
-            <scope>test</scope>
-        </dependency>
 
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -108,12 +108,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.5.5</version>
+            <version>1.5.18</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.5</version>
+            <version>1.5.18</version>
         </dependency>
         <dependency>
             <groupId>com.github.loki4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>8.3.0</version>
+            <version>9.3.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->


### PR DESCRIPTION
## Overview
Updated some dependencies due to vulnerabilities and just in general potentially better usage.

Updated:
- Javalin: 6.3.0 -> 6.6.0
- MySQL: 8.3.0 -> 9.3.0
- Logback: 1.5.5 -> 1.5.18

Also removed a dependency that was duplicate in the pom.xml