### PR TITLE
Approving Submission Post Request No Longer Expects Response

### DIFF
--- a/src/main/resources/frontend/src/services/adminService.ts
+++ b/src/main/resources/frontend/src/services/adminService.ts
@@ -14,11 +14,15 @@ export const submissionsForUserGet = (netId: string): Promise<Submission[]> => {
 };
 
 export const approveSubmissionPost = (netId: string, phase: Phase, penalize: boolean) => {
-  return ServerCommunicator.postRequest("/api/admin/submissions/approve", {
-    netId,
-    phase,
-    penalize,
-  });
+  return ServerCommunicator.postRequest(
+    "/api/admin/submissions/approve",
+    {
+      netId,
+      phase,
+      penalize,
+    },
+    false,
+  );
 };
 
 export const submissionsLatestGet = (batchSize?: number): Promise<Submission[]> => {


### PR DESCRIPTION
## Overview
Resolves #561. The approveSubmissionPost called the ServerCommunicator's postRequest expecting a response, when in actuality, nothing gets returned. This PR now calls the postRequest NOT expecting a response.

## Details
Funnily enough, this hadn't been caught before because the endpoint returned an empty JSON object before the AutoGrader got migrated over to Javalin.
https://github.com/softwareconstruction240/autograder/blob/3c9fdd3197de667c8f04810d1071c9a2798843c1/src/main/java/edu/byu/cs/controller/SubmissionController.java#L204-L209
and when it came back to the ServerCommunicator, when it was expecting a response, it would get the JSON string, parsing it out and returning (as you can see on lines 247-250), not throwing an error!
https://github.com/softwareconstruction240/autograder/blob/3c9fdd3197de667c8f04810d1071c9a2798843c1/src/main/resources/frontend/src/network/ServerCommunicator.ts#L235-L257
But since the migration to Javalin, nothing gets written to the response body, so 'text' is empty, skipping the if-statement in the previously mentioned lines.

## Testing
- [x] Manual testing (if needed) - I have tested this manually approving a test student's submission.
