### PR TITLE
Added clearShutdownSchedule to the end of triggerShutdown

### DIFF
--- a/src/main/java/edu/byu/cs/service/ConfigService.java
+++ b/src/main/java/edu/byu/cs/service/ConfigService.java
@@ -238,6 +238,7 @@ public class ConfigService {
             }
             dao.setConfiguration(ConfigurationDao.Configuration.STUDENT_SUBMISSIONS_ENABLED, phases, ArrayList.class);
             logAutomaticConfigChange("Student submissions have shutdown. These phases remain active: " + phases);
+            clearShutdownSchedule();
         } catch (DataAccessException e) {
             LOGGER.error("Something went wrong while shutting down graded phases: " + e.getMessage());
         }


### PR DESCRIPTION
## Overview
This Pull Request adds one line of code, but that one line of code will automatically turn the shutdown off after finishing shutting down the autograder. 

## Details
To further explain what this means, the autograder will be scheduled to close at midnight on the last day of class. This is so that no students can submit after the deadline and get points due to Campus Policy. Every now and then, we do get a student with Professor permission to turn in an assignment late, and the autograder needs to be opened again. If you just simply try to open a phase, it will fail because the shutdown is still activated. The TA will need to turn off the shutdown before they can open the phases back open. Ultimately, this one line of code doesn't save too much time as stated in the issue discussion, but by doing this, it helps new TAs not struggle when trying to figure out why the autograder phases won't be reopened like I did when I first had to do that for a student. 

## Testing
- [X] Manual testing (I ran the autograder on my local device, set the shutdown for in 1 minute, and tested to see if this edit will allow the phases to be reopened without needing to do anything else. That is true. Also, on a good note, the autograder doesn't crash because of this PR either.)