### PR TITLE
HOTFIX: Incorrect "You are not in queue" message

### DIFF
--- a/src/main/java/edu/byu/cs/controller/WebSocketController.java
+++ b/src/main/java/edu/byu/cs/controller/WebSocketController.java
@@ -32,7 +32,7 @@ public class WebSocketController {
         String netId;
         ctx.enableAutomaticPings(20, TimeUnit.SECONDS);
         try {
-            netId = JwtUtils.validateToken(message);
+            netId = JwtUtils.validateToken(ctx.cookie("token"));
         } catch (Exception e) {
             LOGGER.warn("Exception thrown while validating token: ", e);
             sendError(session, "Invalid token");


### PR DESCRIPTION
## Overview
<!-- Give a brief overview of the changes made in this PR -->

This is a hotfix for the error message that says "You are not in the queue" even though users are in fact in the queue.

The root of the problem was the change in my last PR of the cookie to `HttpOnly`. These queue updates rely on websocket messages that were intiated by sending the user's auth token. In response, they got grading updates. Now that the token is inaccessable, the backend can't get the user.

This was fixed by reading the cookie instead of the websocket message.

## Details
<!-- If you feel it is helpful, list the changes made -->
### Before
<img width="970" height="223" alt="image" src="https://github.com/user-attachments/assets/8ec962b9-560c-4027-9d02-936c12fd2e82" />

<img width="833" height="376" alt="image" src="https://github.com/user-attachments/assets/91cb8617-a50f-4ec8-adc5-c044d7300fcf" />

### After
<img width="970" height="223" alt="image" src="https://github.com/user-attachments/assets/dab49833-00da-40ed-8b23-6b9d0b79075c" />

<img width="648" height="335" alt="image" src="https://github.com/user-attachments/assets/d09f6648-7959-4d37-b076-1ea546feadd5" />


## Testing
<!-- How did you test this? 
     If you didn't do any testing, explain why -->
- [ ] Added/updated unit tests
- [ ] Tested edge cases
- [x] Manual testing (if needed)


## Future Work
<!-- Discuss things that should be done in the future, 
     or related work going on in other issues/PRs.
     Delete this section if there is none. -->

There's a good chance this will cause an error for Test Student, but I'd rather everyone else have the correct display. There's probably also some code cleanup that needs to happen, but I will address this later.
