### PR TITLE
363 case sensitivity

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -3,12 +3,13 @@ networks:
 
 services:
   db:
-    image: mysql:9.0.1
+    image: mysql:9.7.0
+    command: --lower-case-table-names=1
     profiles:
       - with-db
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: "root"
+      MYSQL_ROOT_PASSWORD: "changeme"
     volumes:
       - db-data:/var/lib/mysql
     ports:

--- a/src/main/resources/phases/phase4/passoff/server/DatabaseTests.java
+++ b/src/main/resources/phases/phase4/passoff/server/DatabaseTests.java
@@ -130,9 +130,10 @@ public class DatabaseTests {
                 TestResult result = operation.get();
                 Assertions.assertEquals(500, serverFacade.getStatusCode(),
                         "Server response code was not 500 Internal Error for " + operationName);
-                Assertions.assertNotNull(result.getMessage(), "Invalid Request didn't return an error message for " + operationName);
-                Assertions.assertTrue(result.getMessage().toLowerCase(Locale.ROOT).contains("error"),
-                        "Error message didn't contain the word \"Error\" for " + operationName);
+                String errorMessage = result.getMessage();
+                Assertions.assertNotNull(errorMessage, "Invalid Request didn't return an error message for " + operationName);
+                Assertions.assertTrue(errorMessage.toLowerCase(Locale.ROOT).contains("error"),
+                        String.format("Error message didn't contain the word \"Error\" for %s. Error message: \"%s\"", operationName, errorMessage));
             }
         } finally {
             Method loadFromResources = databaseManagerClass.getDeclaredMethod("loadPropertiesFromResources");


### PR DESCRIPTION
## Overview
<!-- Give a brief overview of the changes made in this PR -->

Resolves #363

This change to the compose file creates a database container that converts all names to lowercase when creating tables or querying them. This makes it so that table names mock the behavior of Windows systems. I also updated the MySQL version.

The change is already live, and I have tested that it does in fact fix the case-sensitivityby adding a capitlized table name to my repository. It passed the phase 4 tests.


## Details
<!-- If you feel it is helpful, list the changes made -->

- Case sensitvity on the database
- Update Phase 4 tests

## Testing
<!-- How did you test this? 
     If you didn't do any testing, explain why -->
- [ ] Added/updated unit tests
- [ ] Tested edge cases
- [x] Manual testing (if needed)

