### PR TITLE
594 frontend autograder fails to load submission details

### DIFF
--- a/src/main/resources/frontend/src/utils/tableUtils.ts
+++ b/src/main/resources/frontend/src/utils/tableUtils.ts
@@ -12,8 +12,8 @@ import {
 export const renderPhaseCell = (params: ValueGetterParams): string => {
   const phase = params.data.phase;
   if (typeof phase !== "string") {
-    console.error("Failed to get phase")
-    return ""
+    console.error("Failed to get phase");
+    return "";
   }
   return params.data.phase.toLowerCase().replace("phase", "");
 };
@@ -24,8 +24,8 @@ export const renderPhaseCell = (params: ValueGetterParams): string => {
 export const renderTimestampCell = (params: ValueGetterParams): string => {
   const stamp = params.data.timestamp;
   if (typeof stamp !== "string") {
-    console.error("Failed to get Timestamp")
-    return ""
+    console.error("Failed to get Timestamp");
+    return "";
   }
   return simpleTimestamp(params.data.timestamp);
 };

--- a/src/main/resources/frontend/src/utils/tableUtils.ts
+++ b/src/main/resources/frontend/src/utils/tableUtils.ts
@@ -10,6 +10,11 @@ import {
  * @param params is an ValueGetterParams Object from AG-Grid that contains a field called "phase"
  */
 export const renderPhaseCell = (params: ValueGetterParams): string => {
+  const phase = params.data.phase;
+  if (typeof phase !== "string") {
+    console.error("Failed to get phase")
+    return ""
+  }
   return params.data.phase.toLowerCase().replace("phase", "");
 };
 
@@ -17,6 +22,11 @@ export const renderPhaseCell = (params: ValueGetterParams): string => {
  * @param params is an ValueGetterParams Object from AG-Grid that contains a field called "timestamp"
  */
 export const renderTimestampCell = (params: ValueGetterParams): string => {
+  const stamp = params.data.timestamp;
+  if (typeof stamp !== "string") {
+    console.error("Failed to get Timestamp")
+    return ""
+  }
   return simpleTimestamp(params.data.timestamp);
 };
 

--- a/src/main/resources/frontend/src/views/AdminView/SubmissionsView.vue
+++ b/src/main/resources/frontend/src/views/AdminView/SubmissionsView.vue
@@ -36,6 +36,12 @@ let adminRepo = reactive({
   value: "",
 });
 
+const gridApi = ref<any>(null);
+
+const onGridReady = (params: any) => {
+  gridApi.value = params.api;
+};
+
 onMounted(async () => {
   await resetPage();
 });
@@ -68,7 +74,7 @@ const loadSubmissionsToTable = (submissionsData: Submission[]) => {
       name: nameFromNetId(submission.netId),
     });
   });
-  rowData.value = dataToShow;
+  gridApi.value!.setGridOption("rowData", dataToShow);
 };
 
 const openSubmission = (event: CellClickedEvent) => {
@@ -167,6 +173,7 @@ const adminSubmit = async () => {
     :columnDefs="columnDefs"
     :rowData="rowData.value"
     :defaultColDef="standardColSettings"
+    @grid-ready="onGridReady"
   ></ag-grid-vue>
 
   <div class="container">


### PR DESCRIPTION
## Overview
<!-- Give a brief overview of the changes made in this PR -->

Resolves #594

The autograder submission details would sometimes not load. I believe this was because of a race condition. The table would start loading before the data was fully loaded. 

## Details
<!-- If you feel it is helpful, list the changes made -->

- I first added error handling if the cell doesn't have the information. In a failed case, it will just be an empty cell. 
- I changed the row update to happen the recommended way from the ag-grid-community website. Once the grid's row values are all updated, it calls the onGridReady function. Updating this way, I never ran into a problem or got the fail case in the cell renderings. 

## Testing
<!-- How did you test this? 
     If you didn't do any testing, explain why -->
- [ ] Added/updated unit tests
- [ ] Tested edge cases
- [x] Manual testing (if needed)

I was able to test it the same way that Melvin showed in the issue. After the changes, I never ran into issues, but I would love people to check it on their own machines. Testing if the cells can be clicked would also be useful. 

## Future Work
<!-- Discuss things that should be done in the future, 
     or related work going on in other issues/PRs.
     Delete this section if there is none. -->
I don't think other tables have this problem, but we could update those in the future as well. 