### PR TITLE
Refactor Authstore in Frontend

### DIFF
--- a/src/main/java/edu/byu/cs/controller/AdminController.java
+++ b/src/main/java/edu/byu/cs/controller/AdminController.java
@@ -4,6 +4,8 @@ import edu.byu.cs.canvas.model.CanvasSection;
 import edu.byu.cs.controller.exception.ResourceNotFoundException;
 import edu.byu.cs.model.User;
 import edu.byu.cs.service.AdminService;
+import edu.byu.cs.service.AuthenticationService;
+import io.javalin.http.Cookie;
 import io.javalin.http.Handler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,7 +29,14 @@ public class AdminController {
 
     public static final Handler testModeGet = ctx -> {
         User testStudent = AdminService.updateTestStudent();
-        ctx.cookie("token", generateToken(testStudent.netId()), 14400);
+        ctx.cookie(new Cookie("token",
+                generateToken(testStudent.netId()),
+                "/",
+                14400,
+                AuthenticationService.isSecure(),
+                0,
+                true)
+        );
     };
 
     public static final Handler commitAnalyticsGet = ctx -> {

--- a/src/main/java/edu/byu/cs/controller/WebSocketController.java
+++ b/src/main/java/edu/byu/cs/controller/WebSocketController.java
@@ -28,7 +28,6 @@ public class WebSocketController {
 
     public static void onMessage(WsMessageContext ctx) {
         Session session = ctx.session;
-        String message = ctx.message();
         String netId;
         ctx.enableAutomaticPings(20, TimeUnit.SECONDS);
         try {
@@ -54,22 +53,6 @@ public class WebSocketController {
         // notify all queue members of the new queue state.
         TrafficController.addSession(netId, session);
         updateAllQueueMembers();
-    }
-
-    /**
-     * Extracts the token from the WebSocket message, authenticates it.
-     * When the token is valid, it returns the netId of the student it belongs to.
-     *
-     * @param message A WebSocket message
-     * @return The students verified netId, or null if the token is invalid or incomplete.
-     */
-    private String authenticateMessage(String message) {
-        try {
-            return JwtUtils.validateToken(message);
-        } catch (Exception e) {
-            LOGGER.warn("Exception thrown while validating token: ", e);
-            return null;
-        }
     }
 
     /**

--- a/src/main/resources/frontend/src/App.vue
+++ b/src/main/resources/frontend/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from "vue";
-import { useAuthStore } from "@/stores/auth";
+import { useUserStore } from "@/stores/user";
 import { loadUser, logoutPost } from "@/services/authService";
 import router from "@/router";
 import "@/assets/fontawesome/css/fontawesome.css";
@@ -13,15 +13,15 @@ import AboutPage from "@/components/AboutPage.vue";
 import { ServerError } from "@/network/ServerError";
 
 const greeting = computed(() => {
-  if (useAuthStore().isLoggedIn) {
-    return `${useAuthStore().user?.firstName} ${useAuthStore().user?.lastName} - ${useAuthStore().user?.netId} (${useAuthStore().user?.role.toLowerCase()}) - `;
+  if (useUserStore().isLoggedIn) {
+    return `${useUserStore().user?.firstName} ${useUserStore().user?.lastName} - ${useUserStore().user?.netId} (${useUserStore().user?.role.toLowerCase()}) - `;
   }
 });
 
 const logOut = async () => {
   try {
     await logoutPost();
-    useAuthStore().user = null;
+    useUserStore().user = null;
   } catch (e) {
     if (e instanceof ServerError) {
       alert(e.message);
@@ -49,9 +49,9 @@ const repoEditDone = () => {
   <header>
     <h1>CS 240 Autograder</h1>
     <h3>This is where you can submit your assignments and view your scores.</h3>
-    <p>{{ greeting }} <a v-if="useAuthStore().isLoggedIn" @click="logOut">Logout</a></p>
-    <p v-if="useAuthStore().user?.repoUrl" @click="openRepoEditor = true" style="cursor: pointer">
-      {{ useAuthStore().user?.repoUrl }}
+    <p>{{ greeting }} <a v-if="useUserStore().isLoggedIn" @click="logOut">Logout</a></p>
+    <p v-if="useUserStore().user?.repoUrl" @click="openRepoEditor = true" style="cursor: pointer">
+      {{ useUserStore().user?.repoUrl }}
       <i class="fa-solid fa-pen-to-square" />
     </p>
     <BannerMessage />
@@ -59,7 +59,7 @@ const repoEditDone = () => {
   <main>
     <PopUp id="repoEditorPopUp" v-if="openRepoEditor" @closePopUp="openRepoEditor = false">
       <h2>Change Repo</h2>
-      <RepoEditor @repoEditSuccess="repoEditDone" :user="useAuthStore().user" />
+      <RepoEditor @repoEditSuccess="repoEditDone" :user="useUserStore().user" />
       This will not affect previous submissions.
     </PopUp>
 

--- a/src/main/resources/frontend/src/components/BannerMessage.vue
+++ b/src/main/resources/frontend/src/components/BannerMessage.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { useAuthStore } from "@/stores/auth";
+import { useUserStore } from "@/stores/user";
 import { useConfigStore } from "@/stores/config";
 
-const authStore = useAuthStore();
+const authStore = useUserStore();
 const config = useConfigStore();
 
 const bannerProps = computed(() => {

--- a/src/main/resources/frontend/src/components/RepoEditor.vue
+++ b/src/main/resources/frontend/src/components/RepoEditor.vue
@@ -3,7 +3,7 @@ import { isPlausibleRepoUrl } from "@/utils/utils";
 import { defineEmits, reactive } from "vue";
 import { adminUpdateRepo, studentUpdateRepo } from "@/services/userService";
 import type { User } from "@/types/types";
-import { useAuthStore } from "@/stores/auth";
+import { useUserStore } from "@/stores/user";
 
 const { user } = defineProps<{
   user: User | null;
@@ -24,7 +24,7 @@ const submitAndCheckRepo = async (sendEmit: (event: any) => void) => {
   waitingForRepoCheck.value = true;
 
   try {
-    if (useAuthStore().user?.role == "ADMIN" && user != null) {
+    if (useUserStore().user?.role == "ADMIN" && user != null) {
       await adminUpdateRepo(newRepoUrl.value, user.netId);
     } else {
       await studentUpdateRepo(newRepoUrl.value);

--- a/src/main/resources/frontend/src/network/ServerCommunicator.ts
+++ b/src/main/resources/frontend/src/network/ServerCommunicator.ts
@@ -207,7 +207,6 @@ async function doUnprocessedRequest(
   endpoint: string,
   bodyObject: Object | null = null,
 ): Promise<Response> {
-
   const response = await fetch(useConfigStore().backendUrl + endpoint, {
     method: method,
     credentials: "include",

--- a/src/main/resources/frontend/src/network/ServerCommunicator.ts
+++ b/src/main/resources/frontend/src/network/ServerCommunicator.ts
@@ -1,4 +1,4 @@
-import { useAuthStore } from "@/stores/auth";
+import { useUserStore } from "@/stores/user";
 import { ServerError } from "@/network/ServerError";
 import { useConfigStore } from "@/stores/config";
 
@@ -208,7 +208,7 @@ async function doUnprocessedRequest(
   endpoint: string,
   bodyObject: Object | null = null,
 ): Promise<Response> {
-  const authToken = useAuthStore().token ?? "";
+  const authToken = useUserStore().token ?? "";
 
   const response = await fetch(useConfigStore().backendUrl + endpoint, {
     method: method,

--- a/src/main/resources/frontend/src/network/ServerCommunicator.ts
+++ b/src/main/resources/frontend/src/network/ServerCommunicator.ts
@@ -1,4 +1,3 @@
-import { useUserStore } from "@/stores/user";
 import { ServerError } from "@/network/ServerError";
 import { useConfigStore } from "@/stores/config";
 
@@ -208,14 +207,12 @@ async function doUnprocessedRequest(
   endpoint: string,
   bodyObject: Object | null = null,
 ): Promise<Response> {
-  const authToken = useUserStore().token ?? "";
 
   const response = await fetch(useConfigStore().backendUrl + endpoint, {
     method: method,
     credentials: "include",
     headers: {
       "Content-Type": "application/json",
-      Authorization: authToken,
     },
     body: bodyObject ? JSON.stringify(bodyObject) : null,
   });

--- a/src/main/resources/frontend/src/router/index.ts
+++ b/src/main/resources/frontend/src/router/index.ts
@@ -1,7 +1,7 @@
 import { createRouter, createWebHistory } from "vue-router";
 import HomeView from "@/views/HomeView.vue";
 import LoginView from "@/views/LoginView.vue";
-import { useAuthStore } from "@/stores/auth";
+import { useUserStore } from "@/stores/user";
 import AdminView from "@/views/AdminView/AdminView.vue";
 import RegisterView from "@/views/RegisterView.vue";
 
@@ -13,11 +13,11 @@ const router = createRouter({
       name: "home",
       component: HomeView,
       beforeEnter: (to, from) => {
-        if (!useAuthStore().isLoggedIn)
+        if (!useUserStore().isLoggedIn)
           // query must be included for login error messages to work correctly
           return { name: "login", query: to.query };
-        if (!useAuthStore().isFullyRegistered) return "/register";
-        if (useAuthStore().user?.role === "ADMIN") return "/admin";
+        if (!useUserStore().isFullyRegistered) return "/register";
+        if (useUserStore().user?.role === "ADMIN") return "/admin";
       },
     },
     {
@@ -25,8 +25,8 @@ const router = createRouter({
       name: "register",
       component: RegisterView,
       beforeEnter: (to, from) => {
-        if (useAuthStore().isFullyRegistered) return "/";
-        if (!useAuthStore().isLoggedIn) return "login";
+        if (useUserStore().isFullyRegistered) return "/";
+        if (!useUserStore().isLoggedIn) return "login";
       },
     },
     {
@@ -34,7 +34,7 @@ const router = createRouter({
       name: "admin",
       component: AdminView,
       beforeEnter: (to, from) => {
-        if (useAuthStore().user?.role !== "ADMIN") return "/";
+        if (useUserStore().user?.role !== "ADMIN") return "/";
       },
     },
     {

--- a/src/main/resources/frontend/src/services/authService.ts
+++ b/src/main/resources/frontend/src/services/authService.ts
@@ -1,4 +1,4 @@
-import { useAuthStore } from "@/stores/auth";
+import { useUserStore } from "@/stores/user";
 import { ServerCommunicator } from "@/network/ServerCommunicator";
 
 type MeResponse = {
@@ -16,7 +16,7 @@ export const loadUser = async () => {
   const loggedInUser = await meGet();
   if (loggedInUser == null) return;
 
-  useAuthStore().user = loggedInUser;
+  useUserStore().user = loggedInUser;
 };
 
 export const logoutPost = () => {

--- a/src/main/resources/frontend/src/stores/config.ts
+++ b/src/main/resources/frontend/src/stores/config.ts
@@ -2,7 +2,7 @@ import { reactive, readonly, ref } from "vue";
 import { defineStore } from "pinia";
 import { Phase, type RubricInfo, type RubricType } from "@/types/types";
 import { getAdminConfig, getPublicConfig } from "@/services/configService";
-import { useAuthStore } from "@/stores/auth";
+import { useUserStore } from "@/stores/user";
 
 type ImportMeta = {
   VITE_APP_BACKEND_URL: string;
@@ -86,7 +86,7 @@ export const useConfigStore = defineStore("config", () => {
   });
 
   const updateConfig = async () => {
-    if (useAuthStore().isLoggedIn) await updateAdminConfig();
+    if (useUserStore().isLoggedIn) await updateAdminConfig();
     await updatePublicConfig();
   };
 

--- a/src/main/resources/frontend/src/stores/submissions.ts
+++ b/src/main/resources/frontend/src/stores/submissions.ts
@@ -54,6 +54,9 @@ export const useSubmissionStore = defineStore("submission", () => {
 export const subscribeToGradingUpdates = (eventHandler: (event: MessageEvent) => void) => {
   const wsBackendUrl = useConfigStore().backendUrl.replace(/^http/, "ws") + "/ws";
   const ws = new WebSocket(wsBackendUrl);
+  ws.onopen = () => {
+    ws.send("");
+  };
   ws.onmessage = (event) => {
     eventHandler(event);
   };

--- a/src/main/resources/frontend/src/stores/submissions.ts
+++ b/src/main/resources/frontend/src/stores/submissions.ts
@@ -3,7 +3,7 @@ import { ref } from "vue";
 import { Phase, type Submission } from "@/types/types";
 import { lastSubmissionGet, submissionsGet, submitGet } from "@/services/submissionService";
 import { useConfigStore } from "@/stores/config";
-import { useAuthStore } from "@/stores/auth";
+import { useUserStore } from "@/stores/user";
 
 type SubmissionsByPhase = {
   [phase: string]: Submission[];
@@ -54,10 +54,6 @@ export const useSubmissionStore = defineStore("submission", () => {
 export const subscribeToGradingUpdates = (eventHandler: (event: MessageEvent) => void) => {
   const wsBackendUrl = useConfigStore().backendUrl.replace(/^http/, "ws") + "/ws";
   const ws = new WebSocket(wsBackendUrl);
-  ws.onopen = () => {
-    const token = useAuthStore().token;
-    ws.send(token);
-  };
   ws.onmessage = (event) => {
     eventHandler(event);
   };

--- a/src/main/resources/frontend/src/stores/user.ts
+++ b/src/main/resources/frontend/src/stores/user.ts
@@ -9,19 +9,13 @@ type User = {
   role: "STUDENT" | "ADMIN";
 };
 
-export const useAuthStore = defineStore("auth", () => {
+export const useUserStore = defineStore("user", () => {
   const user = ref<User | null>(null);
-
-  const token =
-    document.cookie
-      .split("; ")
-      .find((row) => row.startsWith("token"))
-      ?.split("=")[1] || "";
 
   const isLoggedIn = computed(() => user.value !== null);
 
   const isFullyRegistered = computed(() => {
-    const user = useAuthStore().user;
+    const user = useUserStore().user;
     if (user == null) {
       return false;
     }
@@ -33,5 +27,5 @@ export const useAuthStore = defineStore("auth", () => {
     return true;
   });
 
-  return { user, token, isLoggedIn, isFullyRegistered };
+  return { user, isLoggedIn, isFullyRegistered };
 });

--- a/src/main/resources/frontend/src/utils/utils.ts
+++ b/src/main/resources/frontend/src/utils/utils.ts
@@ -9,7 +9,7 @@ import {
   type TestNode,
   VerifiedStatus,
 } from "@/types/types";
-import { useAuthStore } from "@/stores/auth";
+import { useUserStore } from "@/stores/user";
 
 const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
@@ -83,7 +83,7 @@ export const nameFromNetId = (netId: string) => {
  * @param submission
  */
 export const nameOnSubmission = (submission: Submission) => {
-  const user = useAuthStore().user;
+  const user = useUserStore().user;
   if (!user) {
     console.error("Asking for name on submission while logged out");
     return "?";
@@ -304,5 +304,5 @@ export const isLastDateWithinXDays = (dates: Date[] | string[], days: number) =>
 };
 
 export const isAdmin = (): boolean => {
-  return useAuthStore().user?.role === "ADMIN";
+  return useUserStore().user?.role === "ADMIN";
 };

--- a/src/main/resources/frontend/src/views/RegisterView.vue
+++ b/src/main/resources/frontend/src/views/RegisterView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { onBeforeMount } from "vue";
 import { meGet } from "@/services/authService";
-import { useAuthStore } from "@/stores/auth";
+import { useUserStore } from "@/stores/user";
 import router from "@/router";
 import { uiConfig } from "@/stores/uiConfig";
 import { Phase } from "@/types/types";
@@ -11,7 +11,7 @@ onBeforeMount(async () => {
   const loggedInUser = await meGet();
   if (loggedInUser == null) return;
 
-  useAuthStore().user = loggedInUser;
+  useUserStore().user = loggedInUser;
   router.push({ name: "home" });
 });
 
@@ -30,7 +30,7 @@ const goToApp = () => {
     <a target="_blank" :href="uiConfig.getSpecLink(Phase.GitHub)">
       <span>Click here for more info</span>
     </a>
-    <RepoEditor @repoEditSuccess="goToApp" :user="useAuthStore().user" />
+    <RepoEditor @repoEditSuccess="goToApp" :user="useUserStore().user" />
   </div>
 </template>
 

--- a/src/main/resources/frontend/src/views/StudentView/SubmissionInfo.vue
+++ b/src/main/resources/frontend/src/views/StudentView/SubmissionInfo.vue
@@ -14,7 +14,7 @@ import {
 } from "@/utils/utils";
 import RubricItemView from "@/views/StudentView/RubricItemView.vue";
 import InfoPanel from "@/components/InfoPanel.vue";
-import { useAuthStore } from "@/stores/auth";
+import { useUserStore } from "@/stores/user";
 import { approveSubmissionPost } from "@/services/adminService";
 import { ref } from "vue";
 
@@ -65,7 +65,7 @@ const approve = async (penalize: boolean, emit: (event: string, ...args: any[]) 
 
     <div
       v-if="
-        useAuthStore().user?.role == 'ADMIN' &&
+        useUserStore().user?.role == 'ADMIN' &&
         submission.passed &&
         commitVerificationFailed(submission)
       "


### PR DESCRIPTION
## Overview
Resolves #631

When the authentication system switched, I changed the cookies containing the authentication tokens to be http only. This broke some features at the time that used websocket. I made a quick fix, but at the time I was not certain how much else relied on the cookie not being http only.

After looking through the frontend code a little more thoroughly, I've concluded that the code mostly relies on the meGet endpoint call. There is little to no use of the actual token cookie. The websocket seemed to be the only place that was writing the token in manually, and websocket messages are accompanied by their cookies, so this was unecessary. This change was shortly after the authentication was changed.

To avoid future uses of the cookie in the frontend, I've changed the AuthStore into a UserStore. This overall change prevents cross site scripting and is more secure for everyone.

## Details
<!-- If you feel it is helpful, list the changes made -->

- Changed test student to also use an http only cookie
- Removed token references from AuthStore
- Renamed AuthStore to UserStore 
- Removed unused Websocket variables and methods
 
## Testing
<!-- How did you test this? 
     If you didn't do any testing, explain why -->
- [ ] Added/updated unit tests
- [ ] Tested edge cases
- [x] Manual testing (if needed)

