### PR TITLE
Log Code Quality issues

### DIFF
--- a/src/main/java/edu/byu/cs/autograder/quality/QualityAnalyzer.java
+++ b/src/main/java/edu/byu/cs/autograder/quality/QualityAnalyzer.java
@@ -60,7 +60,7 @@ public class QualityAnalyzer {
 
         if(!checkstyleFinished(output)) {
             LOGGER.error("Quality Analysis finished with problems: {}", error);
-            return new QualityAnalysis(0, "", "Could not complete code quality analysis. Please go see a TA.");
+            return new QualityAnalysis(0, error, "Could not complete code quality analysis. Please go see a TA.");
         }
 
         output = output.replaceAll(stageRepo.getAbsolutePath(), "");

--- a/src/main/java/edu/byu/cs/autograder/quality/QualityAnalyzer.java
+++ b/src/main/java/edu/byu/cs/autograder/quality/QualityAnalyzer.java
@@ -59,8 +59,11 @@ public class QualityAnalyzer {
         }
 
         if(!checkstyleFinished(output)) {
-            LOGGER.error("Quality Analysis finished with problems: {}", error);
-            return new QualityAnalysis(0, error, "Could not complete code quality analysis. Please go see a TA.");
+            return new QualityAnalysis(
+                    0,
+                    sanitizeErrorStream(error),
+                    "Could not complete code quality analysis. Please go see a TA."
+            );
         }
 
         output = output.replaceAll(stageRepo.getAbsolutePath(), "");
@@ -183,6 +186,20 @@ public class QualityAnalyzer {
 
     private boolean checkstyleFinished(String output) {
         return output.endsWith("Audit done.\n");
+    }
+
+    /**
+     * Strips path names up to the repo folder
+     *
+     * @param error stream from process builder
+     * @return a new string without full path names
+     */
+    private String sanitizeErrorStream(String error) {
+        String sanitized = error;
+        if (error.contains("repo")) {
+            sanitized = error.replaceAll("[/\\S]*repo/", "");
+        }
+        return sanitized;
     }
 
     /**

--- a/src/main/java/edu/byu/cs/autograder/quality/QualityAnalyzer.java
+++ b/src/main/java/edu/byu/cs/autograder/quality/QualityAnalyzer.java
@@ -3,8 +3,6 @@ package edu.byu.cs.autograder.quality;
 import edu.byu.cs.autograder.GradingException;
 import edu.byu.cs.util.ProcessUtils;
 import edu.byu.cs.util.Serializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileReader;
@@ -24,8 +22,6 @@ public class QualityAnalyzer {
     protected static final String checkStyleJarPath;
 
     private static final QualityRubric qualityRubricItems;
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(QualityAnalyzer.class);
 
     static {
         Path libsPath = new File("phases", "libs").toPath();

--- a/src/main/java/edu/byu/cs/autograder/quality/QualityAnalyzer.java
+++ b/src/main/java/edu/byu/cs/autograder/quality/QualityAnalyzer.java
@@ -3,6 +3,8 @@ package edu.byu.cs.autograder.quality;
 import edu.byu.cs.autograder.GradingException;
 import edu.byu.cs.util.ProcessUtils;
 import edu.byu.cs.util.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileReader;
@@ -22,6 +24,8 @@ public class QualityAnalyzer {
     protected static final String checkStyleJarPath;
 
     private static final QualityRubric qualityRubricItems;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(QualityAnalyzer.class);
 
     static {
         Path libsPath = new File("phases", "libs").toPath();
@@ -45,13 +49,17 @@ public class QualityAnalyzer {
                 .command("java", "-jar", checkStyleJarPath, "-c", "cs240_checks.xml", "repo/shared", "repo/server", "repo/client");
 
         String output;
+        String error;
         try {
-            output = ProcessUtils.runProcess(processBuilder).stdOut();
+            var processOutput = ProcessUtils.runProcess(processBuilder);
+            output = processOutput.stdOut();
+            error = processOutput.stdErr();
         } catch (ProcessUtils.ProcessException e) {
             throw new GradingException("Error running code quality: " + e.getMessage(), e);
         }
 
         if(!checkstyleFinished(output)) {
+            LOGGER.error("Quality Analysis finished with problems: {}", error);
             return new QualityAnalysis(0, "", "Could not complete code quality analysis. Please go see a TA.");
         }
 


### PR DESCRIPTION
## Overview
Resolves #648 

A student came to me with an issue with their repository.

<img width="847" height="600" alt="image" src="https://github.com/user-attachments/assets/3a39ba6f-e15d-46ef-9378-5ee0f6116aca" />

This is fine... as long as the TAs know what's going wrong. In this particular instance, it was a class outside the compile scope that was missing the curly brace to finish the class. The compiler hadn't built the class because it was outside the project, but checkstyle still ran on the file and threw an exception because it wasn't valid Java.

I had to guess this. In an alternate reality, we would have spent hours debugging it.

This PR puts the error stream from the checkstyle in the result notes of this error. This gives the TAs, and maybe an astute student a place to start debugging the error.

<img width="851" height="597" alt="image" src="https://github.com/user-attachments/assets/234cf995-5142-472a-9a65-af91b5f35de8" />

<img width="1293" height="790" alt="image" src="https://github.com/user-attachments/assets/bd6ca736-d71d-490f-9c0c-66ca28f3263a" />


## Testing
<!-- How did you test this? 
     If you didn't do any testing, explain why -->
- [ ] Added/updated unit tests
- [ ] Tested edge cases
- [x] Manual testing (if needed)
