### PR TITLE
657 formatting issue in config tab

### DIFF
--- a/src/main/resources/frontend/src/views/AdminView/ConfigView.vue
+++ b/src/main/resources/frontend/src/views/AdminView/ConfigView.vue
@@ -172,19 +172,21 @@ onMounted(async () => {
       </template>
     </ConfigSection>
 
-    <ConfigSection
-      title="Slack Link"
-      description="The invitation link to the Slack page of the current semester/term"
-    >
-      <template #editor="{ closeEditor }">
-        <SlackLinkConfigEditor :closeEditor="closeEditor" />
-      </template>
-      <template #current>
-        <p>
-          <span class="infoLabel">Slack Link: </span><em>{{ config.public.slackLink }}</em>
-        </p>
-      </template>
-    </ConfigSection>
+    <div class="full-width">
+      <ConfigSection
+        title="Slack Link"
+        description="The invitation link to the Slack page of the current semester/term"
+      >
+        <template #editor="{ closeEditor }">
+          <SlackLinkConfigEditor :closeEditor="closeEditor" />
+        </template>
+        <template #current>
+          <p>
+            <span class="infoLabel">Slack Link: </span><em>{{ config.public.slackLink }}</em>
+          </p>
+        </template>
+      </ConfigSection>
+    </div>
   </div>
 </template>
 
@@ -200,6 +202,10 @@ onMounted(async () => {
 
 .infoLabel {
   font-weight: bold;
+}
+
+.full-width {
+  grid-column: 1 / -1;
 }
 
 #configContainer {

--- a/src/main/resources/frontend/src/views/AdminView/ConfigView.vue
+++ b/src/main/resources/frontend/src/views/AdminView/ConfigView.vue
@@ -182,7 +182,8 @@ onMounted(async () => {
         </template>
         <template #current>
           <p>
-            <span class="infoLabel">Class Community Link: </span><em>{{ config.public.slackLink }}</em>
+            <span class="infoLabel">Class Community Link: </span
+            ><em>{{ config.public.slackLink }}</em>
           </p>
         </template>
       </ConfigSection>

--- a/src/main/resources/frontend/src/views/AdminView/ConfigView.vue
+++ b/src/main/resources/frontend/src/views/AdminView/ConfigView.vue
@@ -174,15 +174,15 @@ onMounted(async () => {
 
     <div class="full-width">
       <ConfigSection
-        title="Slack Link"
-        description="The invitation link to the Slack page of the current semester/term"
+        title="Class Community Link"
+        description="The invitation link to the class community page of the current semester/term"
       >
         <template #editor="{ closeEditor }">
           <SlackLinkConfigEditor :closeEditor="closeEditor" />
         </template>
         <template #current>
           <p>
-            <span class="infoLabel">Slack Link: </span><em>{{ config.public.slackLink }}</em>
+            <span class="infoLabel">Class Community Link: </span><em>{{ config.public.slackLink }}</em>
           </p>
         </template>
       </ConfigSection>


### PR DESCRIPTION
## Overview
<!-- Give a brief overview of the changes made in this PR -->
Resolves #657. 
Fixed some visual bugs in the Config tab of the online autograder.

## Details
<!-- If you feel it is helpful, list the changes made -->
- Made the Discord link section span all the columns so that it doesn't make the formatting squished. 
- Changed the name from Slack link to Class Community Link. 

## Testing
<!-- How did you test this? 
     If you didn't do any testing, explain why -->
- [ ] Added/updated unit tests
- [ ] Tested edge cases
- [x] Manual testing (if needed)

## Future Work
<!-- Discuss things that should be done in the future, 
     or related work going on in other issues/PRs.
     Delete this section if there is none. -->

Slack has been embedded deep within the reaches of the autograder. I only changed the visuals on the website. Lots of variables are still named based on Slack. There's also a /slack endpoint on the server. Future work can do the valiant job of purging us from Slack once and for all. 
