### PR TITLE
Automatic Rubric Config Setup

### DIFF
--- a/docs/getting-started/db-insert-statements/insert-rubric-database.md
+++ b/docs/getting-started/db-insert-statements/insert-rubric-database.md
@@ -10,8 +10,8 @@ The primary things that needs to be updated on an ongoing basis are:
 
 ## Statements
 > [!NOTE]
-> As of **SUMMER 2026** this step is no longer necessary. Rubric Configs are defined in the `RubricConfigDao` interface.
-upda> If you would like to make a change, please update the default configs there. **Live edits still require alter 
+> As of **SUMMER 2026** this step is no longer necessary. Rubric Configs are defined in the `RubricConfigDao` interface. 
+> If you would like to make a change, please update the default configs there. **Live edits still require alter 
 > statments.**
 > 
 > Do make sure that in the config tab, under the course ids that you press the `Reload assignment/rubric ids` button

--- a/docs/getting-started/db-insert-statements/insert-rubric-database.md
+++ b/docs/getting-started/db-insert-statements/insert-rubric-database.md
@@ -10,7 +10,11 @@ The primary things that needs to be updated on an ongoing basis are:
 
 ## Statements
 > [!NOTE]
-> Updated as of **WINTER 2026**
+> As of **SUMMER 2026** this step is no longer necessary. Rubric Configs are defined in the `RubricConfigDao` interface.
+> If you would like to make a change, please update the default configs there.
+> 
+> Do make sure that in the config tab, under the course ids that you press the `Reload assignment/rubric ids` button
+> especially if you do not change the course number on this page
 
 ```mysql
 INSERT INTO rubric_config (phase, type, category, criteria, points, rubric_id) VALUES

--- a/docs/getting-started/db-insert-statements/insert-rubric-database.md
+++ b/docs/getting-started/db-insert-statements/insert-rubric-database.md
@@ -11,10 +11,11 @@ The primary things that needs to be updated on an ongoing basis are:
 ## Statements
 > [!NOTE]
 > As of **SUMMER 2026** this step is no longer necessary. Rubric Configs are defined in the `RubricConfigDao` interface.
-> If you would like to make a change, please update the default configs there.
+upda> If you would like to make a change, please update the default configs there. **Live edits still require alter 
+> statments.**
 > 
 > Do make sure that in the config tab, under the course ids that you press the `Reload assignment/rubric ids` button
-> especially if you do not change the course number on this page
+> especially if you do not change the course number in the autograder config.
 
 ```mysql
 INSERT INTO rubric_config (phase, type, category, criteria, points, rubric_id) VALUES

--- a/src/main/java/edu/byu/cs/dataAccess/DaoService.java
+++ b/src/main/java/edu/byu/cs/dataAccess/DaoService.java
@@ -85,15 +85,6 @@ public class DaoService {
             configurationDao.setConfiguration(ConfigurationDao.Configuration.LINES_PER_COMMIT_REQUIRED, 5, Integer.class);
             configurationDao.setConfiguration(ConfigurationDao.Configuration.CLOCK_FORGIVENESS_MINUTES, 3, Integer.class);
 
-            rubricConfigDao.setRubricConfig(Phase.GitHub, RubricConfigDao.defaultGitHubConfig);
-            rubricConfigDao.setRubricConfig(Phase.Phase0, RubricConfigDao.defaultPhase0Config);
-            rubricConfigDao.setRubricConfig(Phase.Phase1, RubricConfigDao.defaultPhase1Config);
-            rubricConfigDao.setRubricConfig(Phase.Phase3, RubricConfigDao.defaultPhase3Config);
-            rubricConfigDao.setRubricConfig(Phase.Phase4, RubricConfigDao.defaultPhase4Config);
-            rubricConfigDao.setRubricConfig(Phase.Phase5, RubricConfigDao.defaultPhase5Config);
-            rubricConfigDao.setRubricConfig(Phase.Phase6, RubricConfigDao.defaultPhase6Config);
-            rubricConfigDao.setRubricConfig(Phase.Quality, RubricConfigDao.defaultQualityConfig);
-
         } catch (DataAccessException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/edu/byu/cs/dataAccess/daoInterface/RubricConfigDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/daoInterface/RubricConfigDao.java
@@ -97,6 +97,19 @@ public interface RubricConfigDao {
         return total;
     }
 
+    static RubricConfig getDefaultRubricConfig(Phase phase) {
+        return switch (phase){
+            case Phase0 -> defaultPhase0Config;
+            case Phase1 -> defaultPhase1Config;
+            case Phase3 -> defaultPhase3Config;
+            case Phase4 -> defaultPhase4Config;
+            case Phase5 -> defaultPhase5Config;
+            case Phase6 -> defaultPhase6Config;
+            case Quality -> defaultQualityConfig;
+            case GitHub -> defaultGitHubConfig;
+        };
+    }
+
     void setRubricConfig(Phase phase, RubricConfig rubricConfig) throws DataAccessException;
 
     void setRubricIdAndPoints(Phase phase, Rubric.RubricType type, Integer points, String rubric_id) throws DataAccessException;

--- a/src/main/java/edu/byu/cs/dataAccess/daoInterface/RubricConfigDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/daoInterface/RubricConfigDao.java
@@ -69,6 +69,12 @@ public interface RubricConfigDao {
     RubricConfig defaultQualityConfig = new RubricConfig(Phase.Quality, new EnumMap<>(Map.of(
             QUALITY, new RubricConfig.RubricConfigItem("Code Quality", "Chess Code Quality Rubric (see GitHub)", 30, null)
     )));
+
+    /**
+     * Initializes the rubric config table if one is not detected on startup
+     */
+    void setDefaultConfigIfNotExists() throws DataAccessException;
+
     /**
      * Gets the rubric for the given phase
      *

--- a/src/main/java/edu/byu/cs/dataAccess/memory/RubricConfigMemoryDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/memory/RubricConfigMemoryDao.java
@@ -10,6 +10,18 @@ import java.util.Map;
 
 public class RubricConfigMemoryDao implements RubricConfigDao {
     private final Map<Phase, RubricConfig> rubricConfigs = new EnumMap<>(Phase.class);
+
+    public RubricConfigMemoryDao() {
+        setDefaultConfigIfNotExists();
+    }
+
+    @Override
+    public void setDefaultConfigIfNotExists() {
+        for (Phase phase: Phase.values()) {
+            this.setRubricConfig(phase, RubricConfigDao.getDefaultRubricConfig(phase));
+        }
+    }
+
     @Override
     public RubricConfig getRubricConfig(Phase phase) {
         return rubricConfigs.get(phase);

--- a/src/main/java/edu/byu/cs/dataAccess/sql/RubricConfigSqlDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/sql/RubricConfigSqlDao.java
@@ -29,11 +29,11 @@ public class RubricConfigSqlDao implements RubricConfigDao {
     public void setDefaultConfigIfNotExists() throws DataAccessException {
         for (Phase phase : Phase.values()){
             RubricConfig config = getRubricConfig(phase);
-            RubricConfig defalt = RubricConfigDao.getDefaultRubricConfig(phase);
+            RubricConfig defaultRubricConfig = RubricConfigDao.getDefaultRubricConfig(phase);
             if (config.items().isEmpty() || isEmptyConfig(config)){
-                setRubricConfig(phase, defalt);
+                setRubricConfig(phase, defaultRubricConfig);
             }
-            else if (!defalt.equals(config)){
+            else if (!defaultRubricConfig.equals(config)){
                 suppressRubricIdWarnings(config);
             }
         }

--- a/src/main/java/edu/byu/cs/dataAccess/sql/RubricConfigSqlDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/sql/RubricConfigSqlDao.java
@@ -12,6 +12,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class RubricConfigSqlDao implements RubricConfigDao {
 
@@ -27,15 +28,13 @@ public class RubricConfigSqlDao implements RubricConfigDao {
     @Override
     public void setDefaultConfigIfNotExists() throws DataAccessException {
         for (Phase phase : Phase.values()){
-        //see if an existing rubric config exists
             RubricConfig config = getRubricConfig(phase);
-        //write out the default rubric config if none exist
             RubricConfig defalt = RubricConfigDao.getDefaultRubricConfig(phase);
             if (config.items().isEmpty() || isEmptyConfig(config)){
                 setRubricConfig(phase, defalt);
             }
             else if (!defalt.equals(config)){
-                LOGGER.warn("Rubric config does not match default: {}", config.toString());
+                suppressRubricIdWarnings(config);
             }
         }
     }
@@ -47,6 +46,19 @@ public class RubricConfigSqlDao implements RubricConfigDao {
             }
         }
         return true;
+    }
+
+    private void suppressRubricIdWarnings(RubricConfig config){
+        RubricConfig rubricDefault = RubricConfigDao.getDefaultRubricConfig(config.phase());
+        for (var key : config.items().keySet()){
+            var defaultItem = rubricDefault.items().get(key);
+            var configItem = config.items().get(key);
+            if (configItem.points() != defaultItem.points() ||
+                    !Objects.equals(configItem.criteria(), defaultItem.criteria()) ||
+                    !Objects.equals(configItem.category(), defaultItem.category())) {
+                LOGGER.warn("Rubric config does not match default: {}", config);
+            }
+        }
     }
 
     @Override

--- a/src/main/java/edu/byu/cs/dataAccess/sql/RubricConfigSqlDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/sql/RubricConfigSqlDao.java
@@ -53,9 +53,9 @@ public class RubricConfigSqlDao implements RubricConfigDao {
         for (var key : config.items().keySet()){
             var defaultItem = rubricDefault.items().get(key);
             var configItem = config.items().get(key);
-            if (configItem.points() != defaultItem.points() ||
+            if ( configItem != null && (configItem.points() != defaultItem.points() ||
                     !Objects.equals(configItem.criteria(), defaultItem.criteria()) ||
-                    !Objects.equals(configItem.category(), defaultItem.category())) {
+                    !Objects.equals(configItem.category(), defaultItem.category()))) {
                 LOGGER.warn("Rubric config does not match default: {}", config);
             }
         }

--- a/src/main/java/edu/byu/cs/dataAccess/sql/RubricConfigSqlDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/sql/RubricConfigSqlDao.java
@@ -31,13 +31,22 @@ public class RubricConfigSqlDao implements RubricConfigDao {
             RubricConfig config = getRubricConfig(phase);
         //write out the default rubric config if none exist
             RubricConfig defalt = RubricConfigDao.getDefaultRubricConfig(phase);
-            if (config.items().isEmpty()){
+            if (config.items().isEmpty() || isEmptyConfig(config)){
                 setRubricConfig(phase, defalt);
             }
             else if (!defalt.equals(config)){
                 LOGGER.warn("Rubric config does not match default: {}", config.toString());
             }
         }
+    }
+
+    private boolean isEmptyConfig(RubricConfig config){
+        for (RubricConfig.RubricConfigItem item : config.items().values()){
+            if (item != null){
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/edu/byu/cs/dataAccess/sql/RubricConfigSqlDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/sql/RubricConfigSqlDao.java
@@ -5,6 +5,8 @@ import edu.byu.cs.dataAccess.daoInterface.RubricConfigDao;
 import edu.byu.cs.model.Phase;
 import edu.byu.cs.model.Rubric;
 import edu.byu.cs.model.RubricConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -13,8 +15,30 @@ import java.util.Map;
 
 public class RubricConfigSqlDao implements RubricConfigDao {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(RubricConfigDao.class);
+
     // NOTE: This class skipped for conversion to SqlReader since it wouldn't improve readability of this file.
     // This file isn't heavy in SQl queries, but in the logic of joining together the results.
+
+    public RubricConfigSqlDao () throws DataAccessException{
+        setDefaultConfigIfNotExists();
+    }
+
+    @Override
+    public void setDefaultConfigIfNotExists() throws DataAccessException {
+        for (Phase phase : Phase.values()){
+        //see if an existing rubric config exists
+            RubricConfig config = getRubricConfig(phase);
+        //write out the default rubric config if none exist
+            RubricConfig defalt = RubricConfigDao.getDefaultRubricConfig(phase);
+            if (config.items().isEmpty()){
+                setRubricConfig(phase, defalt);
+            }
+            else if (!defalt.equals(config)){
+                LOGGER.warn("Rubric config does not match default: {}", config.toString());
+            }
+        }
+    }
 
     @Override
     public RubricConfig getRubricConfig(Phase phase) throws DataAccessException {

--- a/src/main/java/edu/byu/cs/model/RubricConfig.java
+++ b/src/main/java/edu/byu/cs/model/RubricConfig.java
@@ -1,6 +1,7 @@
 package edu.byu.cs.model;
 
 import java.util.EnumMap;
+import java.util.Objects;
 
 /**
  * Represents the configuration of rubric items for a single phase
@@ -28,4 +29,20 @@ public record RubricConfig(
             String rubric_id
     ) { }
 
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof RubricConfig that)) return false;
+        if (phase != that.phase) return false;
+        for (var key : items.keySet()){
+            if (!Objects.equals(items.get(key), that.items.get(key))){
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(phase, items);
+    }
 }

--- a/src/test/java/edu/byu/cs/dataAccess/base/RubricConfigDaoTest.java
+++ b/src/test/java/edu/byu/cs/dataAccess/base/RubricConfigDaoTest.java
@@ -108,6 +108,15 @@ public abstract class RubricConfigDaoTest {
         Assertions.assertEquals(0, obtained);
     }
 
+    @ParameterizedTest
+    @EnumSource (Phase.class)
+    void daoInitializesWithDefaultConfig(Phase phase) throws DataAccessException {
+        dao = getRubricConfigDao();
+        RubricConfig defalt = RubricConfigDao.getDefaultRubricConfig(phase);
+        RubricConfig startup = dao.getRubricConfig(phase);
+        Assertions.assertEquals(defalt, startup);
+    }
+
     RubricConfig generateRubricConfig(Phase phase){
         return generateRubricConfig(phase, 240);
     }

--- a/src/test/java/edu/byu/cs/dataAccess/base/RubricConfigDaoTest.java
+++ b/src/test/java/edu/byu/cs/dataAccess/base/RubricConfigDaoTest.java
@@ -19,7 +19,7 @@ import java.util.Random;
 public abstract class RubricConfigDaoTest {
 
     protected RubricConfigDao dao;
-    protected abstract RubricConfigDao getRubricConfigDao();
+    protected abstract RubricConfigDao getRubricConfigDao() throws DataAccessException;
     protected abstract void clearRubricConfigDao() throws DataAccessException;
     static Random random = new Random();
 

--- a/src/test/java/edu/byu/cs/dataAccess/base/RubricConfigDaoTest.java
+++ b/src/test/java/edu/byu/cs/dataAccess/base/RubricConfigDaoTest.java
@@ -112,9 +112,9 @@ public abstract class RubricConfigDaoTest {
     @EnumSource (Phase.class)
     void daoInitializesWithDefaultConfig(Phase phase) throws DataAccessException {
         dao = getRubricConfigDao();
-        RubricConfig defalt = RubricConfigDao.getDefaultRubricConfig(phase);
+        RubricConfig defaultRubricConfig = RubricConfigDao.getDefaultRubricConfig(phase);
         RubricConfig startup = dao.getRubricConfig(phase);
-        Assertions.assertEquals(defalt, startup);
+        Assertions.assertEquals(defaultRubricConfig, startup);
     }
 
     RubricConfig generateRubricConfig(Phase phase){

--- a/src/test/java/edu/byu/cs/dataAccess/memory/RubricConfigMemoryDaoTest.java
+++ b/src/test/java/edu/byu/cs/dataAccess/memory/RubricConfigMemoryDaoTest.java
@@ -1,7 +1,9 @@
 package edu.byu.cs.dataAccess.memory;
 
+import edu.byu.cs.dataAccess.DataAccessException;
 import edu.byu.cs.dataAccess.base.RubricConfigDaoTest;
 import edu.byu.cs.dataAccess.daoInterface.RubricConfigDao;
+import edu.byu.cs.model.Phase;
 
 public class RubricConfigMemoryDaoTest extends RubricConfigDaoTest {
     @Override
@@ -10,7 +12,9 @@ public class RubricConfigMemoryDaoTest extends RubricConfigDaoTest {
     }
 
     @Override
-    protected void clearRubricConfigDao() {
-        dao = new RubricConfigMemoryDao();
+    protected void clearRubricConfigDao() throws DataAccessException {
+        for (Phase phase :Phase.values()) {
+            dao.setRubricConfig(phase, null);
+        }
     }
 }

--- a/src/test/java/edu/byu/cs/dataAccess/sql/RubricConfigSqlDaoTest.java
+++ b/src/test/java/edu/byu/cs/dataAccess/sql/RubricConfigSqlDaoTest.java
@@ -12,7 +12,7 @@ public class RubricConfigSqlDaoTest extends RubricConfigDaoTest {
     }
 
     @Override
-    protected RubricConfigDao getRubricConfigDao() {
+    protected RubricConfigDao getRubricConfigDao() throws DataAccessException {
         return new RubricConfigSqlDao();
     }
 


### PR DESCRIPTION
## Overview
<!-- Give a brief overview of the changes made in this PR -->
Resolves #650

This PR should cut back on required intial setup as it will setup the Rubric Config Database Table automatically if there is none detected.

## Details
<!-- If you feel it is helpful, list the changes made -->

- `RubricConfigDao` interface reuqires a method to setup default configs
- Memory and sql dao constructors call the setup default configs method
- Added unit test to confirm this
- changed memory dao unit test clear implementation
- changed `RubricConfig` equals method to consider null rubric items and missing rubric items the same
- SQL dao logs warnings when the config differs from the default (except for rubric id differences)
- updated documentation

## Testing
<!-- How did you test this? 
     If you didn't do any testing, explain why -->
- [x] Added/updated unit tests
- [ ] Tested edge cases
- [ ] Manual testing (if needed)

## Dependencies
<!-- Discuss things that should be done in the future, 
     or related work going on in other issues/PRs.
     Delete this section if there is none. -->

For #643, make sure to merge this and update the startup statements, and problably the documentation.
