### PR TITLE
fix bump to incompatible maven verision

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:4.0.0-rc-5-amazoncorretto-25-debian-trixie AS builder
+FROM maven:3.9.16-amazoncorretto-25-debian-trixie AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Overview
<!-- Give a brief overview of the changes made in this PR -->
The following error was given when anyone tried to compile in the autograder for version 1.2.4:
<img width="1707" height="642" alt="image" src="https://github.com/user-attachments/assets/527bbdf1-ab49-49c2-b150-ad47881361d6" />

I was unable to replicate it on my machine, but it seems the issue was the release used Maven 4 instead of Maven 3, which has a different way to use absolute paths within the project. 

This PR downpatches down to Maven 3.