### PR TITLE
Test improvements

### DIFF
--- a/src/main/java/edu/byu/cs/dataAccess/memory/SubmissionMemoryDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/memory/SubmissionMemoryDao.java
@@ -105,8 +105,14 @@ public class SubmissionMemoryDao implements SubmissionDao {
         Collection<Submission> submissions = getSubmissionsForPhase(netId, phase);
         Submission bestSubmission =  null;
         for (Submission s : submissions) {
-            if (bestSubmission == null) { bestSubmission = s; }
-            else if (s.score() > bestSubmission.score() && s.passed()) { bestSubmission = s; }
+            if (bestSubmission == null) {
+                bestSubmission = s;
+            }
+            else if (s.score() > bestSubmission.score() && s.passed()) {
+                bestSubmission = s;
+            } else if (s.score().equals(bestSubmission.score()) && s.passed() && s.timestamp().getEpochSecond() < bestSubmission.timestamp().getEpochSecond()) {
+                bestSubmission = s;
+            }
         }
         if (bestSubmission == null || !bestSubmission.passed()){
             return null;

--- a/src/main/java/edu/byu/cs/dataAccess/sql/SubmissionSqlDao.java
+++ b/src/main/java/edu/byu/cs/dataAccess/sql/SubmissionSqlDao.java
@@ -189,7 +189,7 @@ public class SubmissionSqlDao implements SubmissionDao {
         var submissions = sqlReader.executeQuery(
                 """
                     WHERE net_id = ? AND phase = ? AND passed = 1
-                        ORDER BY score DESC
+                        ORDER BY score DESC, timestamp ASC
                         LIMIT 1
                     """,
                 ps -> {

--- a/src/test/java/edu/byu/cs/autograder/git/GitHelperTest.java
+++ b/src/test/java/edu/byu/cs/autograder/git/GitHelperTest.java
@@ -46,7 +46,7 @@ class GitHelperTest {
     }
 
     @Test
-    void multiPhaseSuccessfullPassoff() {
+    void multiPhaseSuccessfulPassoff() {
         utils.evaluateTest("multi-phase-successful-passoff", List.of(
                 new VerificationCheckpoint(
                         repoContext -> {

--- a/src/test/java/edu/byu/cs/dataAccess/base/SubmissionDaoTest.java
+++ b/src/test/java/edu/byu/cs/dataAccess/base/SubmissionDaoTest.java
@@ -311,7 +311,6 @@ public abstract class SubmissionDaoTest {
 
     @ParameterizedTest
     @EnumSource(value = Phase.class)
-    @Disabled
     void getBestSubmissionWithDuplicateScore(Phase phase) throws DataAccessException {
         Collection<Submission> submissions = new ArrayList<>();
         for (int i = 0; i < SUBMISSIONS_PER_PHASE; i++) {
@@ -321,7 +320,6 @@ public abstract class SubmissionDaoTest {
             submissions.add(duplicate);
         }
 
-        //FIXME: what is the tie-breaker here? because it's not time and the code doesn't seem to care
         Submission expected = findFirstPassing(submissions);
         Submission actual = dao.getBestSubmissionForPhase(DaoTestUtils.generateNetID(userID), phase);
         assertSubmissionDeepEquals(expected, actual, "Best Submissions do not match");


### PR DESCRIPTION
## Overview
Modified the SQL/Memory DAO implementations of getBestSubmissionForPhase() to retreive the best submission by score AND by date, rather than just by score.

This change enabled the SubmissionDaoTest.getBestSubmissionWithDuplicateScore test to work properly, so it has been re-enabled.

I figure I might as well submit this PR now, because having the oldest submission with the highest score will be relevant for #664 

## Details
- SubmissionSqlDao now sorts by score DESC and timestamp ASC
- SubmissionsMemoryDao now checks timestamps when iterating through submissions.

## Testing
- [x] Added/updated unit tests
- [x] Tested edge cases
- [ ] Manual testing (if needed)